### PR TITLE
Fix missing asset portfolio display values

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -67,6 +67,15 @@ service cloud.firestore {
       allow delete: if isOwner(resource.data.userId);
     }
 
+    // Collezione assetAllocationTargets - target di allocazione asset
+    match /assetAllocationTargets/{targetId} {
+      allow read: if isAuthenticated() && resource.data.userId == request.auth.uid;
+      allow create: if isAuthenticated() && hasValidUserId();
+      allow update: if isOwner(resource.data.userId) &&
+                       request.resource.data.userId == resource.data.userId;
+      allow delete: if isOwner(resource.data.userId);
+    }
+
     // Blocca tutto il resto per sicurezza
     match /{document=**} {
       allow read, write: if false;

--- a/lib/services/snapshotService.ts
+++ b/lib/services/snapshotService.ts
@@ -17,7 +17,7 @@ import {
 } from './assetService';
 import { calculateCurrentAllocation } from './assetAllocationService';
 
-const SNAPSHOTS_COLLECTION = 'monthlySnapshots';
+const SNAPSHOTS_COLLECTION = 'monthly-snapshots';
 
 /**
  * Create a monthly snapshot from current assets


### PR DESCRIPTION
Dashboard Overview:
- Aggiunto caricamento dinamico degli assets con useEffect e useAuth
- Implementati calcoli reali per Patrimonio Totale, Patrimonio Liquido e Numero Assets
- Aggiunti formatCurrency per visualizzazione corretta dei valori
- Aggiunto stato di loading durante il caricamento

Permessi Firebase:
- Corretto nome collection da 'monthlySnapshots' a 'monthly-snapshots' per match con firestore.rules
- Aggiunte regole di sicurezza per collection 'assetAllocationTargets'
- Risolti errori "Missing or insufficient permissions" nelle pagine Allocation, History e Settings

I valori hardcoded sono stati sostituiti con calcoli dinamici usando:
- calculateTotalValue(assets) per patrimonio totale
- calculateLiquidNetWorth(assets) per patrimonio liquido (escluso immobili e private equity)
- assets.length per numero assets