### PR TITLE
Italian greeting and incomplete request

### DIFF
--- a/types/assets.ts
+++ b/types/assets.ts
@@ -42,6 +42,8 @@ export interface SubCategoryConfig {
 export interface AssetAllocationTarget {
   [assetClass: string]: {
     targetPercentage: number;
+    useFixedAmount?: boolean;
+    fixedAmount?: number;
     subCategoryConfig?: SubCategoryConfig;
     subTargets?: {
       [subCategory: string]: number;


### PR DESCRIPTION
- Aggiunge campi useFixedAmount e fixedAmount in AssetAllocationTarget
- Permette di impostare la liquidità come valore fisso in euro tramite toggle
- Le percentuali delle altre asset class si applicano al patrimonio rimanente
- Aggiorna il calcolo automatico di bonds per considerare la liquidità fissa
- Modifica compareAllocations per gestire correttamente i target con liquidità fissa
- Aggiunge validazione e note esplicative nella pagina Settings