### PR TITLE
Implement new feature from previous session

### DIFF
--- a/lib/services/assetAllocationService.ts
+++ b/lib/services/assetAllocationService.ts
@@ -112,15 +112,16 @@ export function calculateCurrentAllocation(assets: Asset[]): {
           byAssetClass[comp.assetClass] = 0;
         }
         byAssetClass[comp.assetClass] += compValue;
-      });
 
-      // Per le sottocategorie, usa l'asset class principale e la subCategory dell'asset
-      if (asset.subCategory) {
-        if (!bySubCategory[asset.subCategory]) {
-          bySubCategory[asset.subCategory] = 0;
+        // Aggregate by sub-category if present in composition
+        // Ogni componente può avere la sua sottocategoria specifica
+        if (comp.subCategory) {
+          if (!bySubCategory[comp.subCategory]) {
+            bySubCategory[comp.subCategory] = 0;
+          }
+          bySubCategory[comp.subCategory] += compValue;
         }
-        bySubCategory[asset.subCategory] += value;
-      }
+      });
     } else {
       // Asset semplice (senza composizione) - comportamento normale
 

--- a/types/assets.ts
+++ b/types/assets.ts
@@ -6,6 +6,7 @@ export type AssetClass = 'equity' | 'bonds' | 'crypto' | 'realestate' | 'cash' |
 export interface AssetComposition {
   assetClass: AssetClass;
   percentage: number;
+  subCategory?: string; // Sottocategoria specifica per questa componente dell'asset composto
 }
 
 export interface Asset {


### PR DESCRIPTION
Implementato il supporto per associare una sottocategoria specifica a ogni componente di un asset composto (es. fondo pensione).

Modifiche:
- Aggiunto campo opzionale 'subCategory' a AssetComposition
- Aggiornato calculateCurrentAllocation per distribuire il valore tra le sottocategorie in base alla componente specifica
- Aggiornata UI AssetDialog con Select per sottocategoria per ogni componente della composizione
- Le sottocategorie vengono mostrate solo se abilitate per l'asset class della componente

Questo risolve il problema dei conteggi incorretti nelle statistiche per sottocategoria quando si utilizzano asset composti.