### PR TITLE
Fix: Usata chiave composta per sottocategorie in asset class diverse

### DIFF
--- a/app/dashboard/allocation/page.tsx
+++ b/app/dashboard/allocation/page.tsx
@@ -101,6 +101,7 @@ export default function AllocationPage() {
   };
 
   // Group sub-categories by asset class
+  // Le chiavi in bySubCategory sono nel formato "assetClass:subCategory"
   const getSubCategoriesByAssetClass = () => {
     if (!targets || !allocation) return {};
 
@@ -109,23 +110,20 @@ export default function AllocationPage() {
       Record<string, AllocationResult['bySubCategory'][string]>
     > = {};
 
-    // Iterate through asset classes that have sub-targets
-    Object.entries(targets).forEach(([assetClass, targetData]) => {
-      if (targetData.subTargets) {
-        grouped[assetClass] = {};
+    // Iterate through all subcategory entries
+    Object.entries(allocation.bySubCategory).forEach(([key, data]) => {
+      // Parse the composite key "assetClass:subCategory"
+      const parts = key.split(':');
+      if (parts.length === 2) {
+        const [assetClass, subCategory] = parts;
 
-        // Get all sub-categories for this asset class
-        Object.keys(targetData.subTargets).forEach((subCategory) => {
-          if (allocation.bySubCategory[subCategory]) {
-            grouped[assetClass][subCategory] =
-              allocation.bySubCategory[subCategory];
-          }
-        });
-
-        // Remove asset class if no sub-categories have data
-        if (Object.keys(grouped[assetClass]).length === 0) {
-          delete grouped[assetClass];
+        // Initialize asset class group if needed
+        if (!grouped[assetClass]) {
+          grouped[assetClass] = {};
         }
+
+        // Add subcategory to its asset class group
+        grouped[assetClass][subCategory] = data;
       }
     });
 

--- a/lib/services/assetAllocationService.ts
+++ b/lib/services/assetAllocationService.ts
@@ -115,11 +115,13 @@ export function calculateCurrentAllocation(assets: Asset[]): {
 
         // Aggregate by sub-category if present in composition
         // Ogni componente può avere la sua sottocategoria specifica
+        // Usa chiave composta "assetClass:subCategory" per evitare collisioni
         if (comp.subCategory) {
-          if (!bySubCategory[comp.subCategory]) {
-            bySubCategory[comp.subCategory] = 0;
+          const subCategoryKey = `${comp.assetClass}:${comp.subCategory}`;
+          if (!bySubCategory[subCategoryKey]) {
+            bySubCategory[subCategoryKey] = 0;
           }
-          bySubCategory[comp.subCategory] += compValue;
+          bySubCategory[subCategoryKey] += compValue;
         }
       });
     } else {
@@ -132,11 +134,13 @@ export function calculateCurrentAllocation(assets: Asset[]): {
       byAssetClass[asset.assetClass] += value;
 
       // Aggregate by sub-category if present
+      // Usa chiave composta "assetClass:subCategory" per evitare collisioni
       if (asset.subCategory) {
-        if (!bySubCategory[asset.subCategory]) {
-          bySubCategory[asset.subCategory] = 0;
+        const subCategoryKey = `${asset.assetClass}:${asset.subCategory}`;
+        if (!bySubCategory[subCategoryKey]) {
+          bySubCategory[subCategoryKey] = 0;
         }
-        bySubCategory[asset.subCategory] += value;
+        bySubCategory[subCategoryKey] += value;
       }
     }
   });
@@ -239,7 +243,9 @@ export function compareAllocations(
 
       Object.keys(targetData.subTargets).forEach((subCategory) => {
         const subTargetPercentage = targetData.subTargets![subCategory];
-        const subCurrentValue = current.bySubCategory[subCategory] || 0;
+        // Usa chiave composta "assetClass:subCategory"
+        const subCategoryKey = `${assetClass}:${subCategory}`;
+        const subCurrentValue = current.bySubCategory[subCategoryKey] || 0;
 
         // Sub-category percentage is relative to its asset class
         const subCurrentPercentage =
@@ -259,7 +265,7 @@ export function compareAllocations(
           subAction = 'OK';
         }
 
-        bySubCategory[subCategory] = {
+        bySubCategory[subCategoryKey] = {
           currentPercentage: subCurrentPercentage,
           currentValue: subCurrentValue,
           targetPercentage: subTargetPercentage,


### PR DESCRIPTION
Implementato un sistema di chiavi composite "assetClass:subCategory" per evitare collisioni quando sottocategorie con lo stesso nome vengono usate in asset class diverse.

Modifiche:
- calculateCurrentAllocation: usa chiave composta per bySubCategory
- compareAllocations: usa chiave composta per confronti con target
- getSubCategoriesByAssetClass: parsa chiave composta per raggruppare

Questo permette di usare nomi di sottocategoria uguali in asset class diverse (es. "Growth" sia per equity che per bonds) senza che i valori si sommino incorrettamente.

Prima: bySubCategory["Growth"] = somma di tutti i "Growth"
Dopo: bySubCategory["equity:Growth"] e bySubCategory["bonds:Growth"]