### PR TITLE
Add planned annual expenses to FIRE settings and metrics

### DIFF
--- a/lib/services/assetAllocationService.ts
+++ b/lib/services/assetAllocationService.ts
@@ -22,11 +22,12 @@ export async function getSettings(
 
     const data = targetDoc.data();
 
-    // Support both old format (only targets) and new format (with userAge, riskFreeRate, and withdrawalRate)
+    // Support both old format (only targets) and new format (with userAge, riskFreeRate, withdrawalRate, and plannedAnnualExpenses)
     return {
       userAge: data.userAge,
       riskFreeRate: data.riskFreeRate,
       withdrawalRate: data.withdrawalRate,
+      plannedAnnualExpenses: data.plannedAnnualExpenses,
       targets: data.targets as AssetAllocationTarget,
     };
   } catch (error) {
@@ -60,6 +61,7 @@ export async function setSettings(
       userAge: settings.userAge,
       riskFreeRate: settings.riskFreeRate,
       withdrawalRate: settings.withdrawalRate,
+      plannedAnnualExpenses: settings.plannedAnnualExpenses,
       targets: settings.targets,
       updatedAt: Timestamp.now(),
     });

--- a/lib/services/fireService.ts
+++ b/lib/services/fireService.ts
@@ -19,6 +19,16 @@ export interface FIREMetrics {
   yearsOfExpenses: number; // Anni di spesa
 }
 
+export interface PlannedFIREMetrics {
+  // Input values
+  plannedAnnualExpenses: number;
+  withdrawalRate: number;
+
+  // Calculated values
+  plannedFireNumber: number;
+  plannedProgressToFI: number; // Percentage
+}
+
 export interface MonthlyFIREData {
   year: number;
   month: number;
@@ -107,6 +117,29 @@ export function calculateFIREMetrics(
     dailyAllowance,
     currentWR,
     yearsOfExpenses,
+  };
+}
+
+/**
+ * Calculate planned FIRE metrics based on user-provided planned annual expenses
+ */
+export function calculatePlannedFIREMetrics(
+  currentNetWorth: number,
+  plannedAnnualExpenses: number,
+  withdrawalRate: number
+): PlannedFIREMetrics {
+  // Planned FIRE Number = Planned Annual Expenses / Withdrawal Rate (as decimal)
+  const wrDecimal = withdrawalRate / 100;
+  const plannedFireNumber = wrDecimal > 0 ? plannedAnnualExpenses / wrDecimal : 0;
+
+  // Planned Progress to FI = (Current Net Worth / Planned FIRE Number) * 100
+  const plannedProgressToFI = plannedFireNumber > 0 ? (currentNetWorth / plannedFireNumber) * 100 : 0;
+
+  return {
+    plannedAnnualExpenses,
+    withdrawalRate,
+    plannedFireNumber,
+    plannedProgressToFI,
   };
 }
 

--- a/types/assets.ts
+++ b/types/assets.ts
@@ -69,6 +69,7 @@ export interface AssetAllocationSettings {
   userAge?: number;
   riskFreeRate?: number;
   withdrawalRate?: number; // Safe withdrawal rate for FIRE calculations (e.g., 4.0 for 4%)
+  plannedAnnualExpenses?: number; // Planned annual expenses for FIRE projections
   targets: AssetAllocationTarget;
 }
 


### PR DESCRIPTION
Introduces support for user-defined planned annual expenses in FIRE calculations. Updates the settings model, UI, and services to allow users to input and save planned annual expenses, and displays projected FIRE metrics based on these values alongside current metrics.