### PR TITLE
Fix: firestore.indexes.json missing indexes and wrong sort order

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -15,6 +15,20 @@
       ]
     },
     {
+      "collectionGroup": "assets",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "isin",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "monthly-snapshots",
       "queryScope": "COLLECTION",
       "fields": [
@@ -24,10 +38,38 @@
         },
         {
           "fieldPath": "year",
-          "order": "DESCENDING"
+          "order": "ASCENDING"
         },
         {
           "fieldPath": "month",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "expenseCategories",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "name",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "expenses",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "date",
           "order": "DESCENDING"
         }
       ]
@@ -75,20 +117,6 @@
         {
           "fieldPath": "paymentDate",
           "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "assets",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "userId",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "isin",
-          "order": "ASCENDING"
         }
       ]
     }


### PR DESCRIPTION
## Problem

Fresh deployments fail with `FirebaseError: The query requires an index` on multiple pages (Dashboard, Cashflow, Patrimonio) due to three issues in `firestore.indexes.json`.

Closes #113

## Root causes

### 1. `monthly-snapshots` — wrong sort order
The index defines `year` and `month` as `DESCENDING`, but `snapshotService.ts` queries with `orderBy('year', 'asc'), orderBy('month', 'asc')`. Firestore treats these as different indexes and refuses the query.

```ts
// snapshotService.ts — lines 144-145
orderBy('year', 'asc'),
orderBy('month', 'asc')
```

### 2. `expenses` — index missing
`expenseService.ts` queries `expenses` with `where('userId', '==', userId)` + `orderBy('date', 'desc')` (lines 74, 112, 147), but no composite index existed for this collection.

### 3. `expenseCategories` — index missing
`expenseCategoryService.ts` queries `expenseCategories` with `where('userId', '==', userId)` + `orderBy('name', 'asc')` (lines 74, 107), but no composite index existed for this collection.

## Fix

- Fix `monthly-snapshots` sort order: `DESCENDING` → `ASCENDING` for both `year` and `month`
- Add `expenses` composite index: `(userId ASC, date DESC)`
- Add `expenseCategories` composite index: `(userId ASC, name ASC)`

Only `firestore.indexes.json` is changed — no application logic touched.