### PR TITLE
fix(ui): token-compliant colors and design system alignment across Pa…

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -199,7 +199,8 @@ Five chart colors cover the semantic range of portfolio data. These are the syst
 - **Title** (600 weight, 1rem, lh 1.4, ls -0.005em): Sub-section headers, table group labels, the step below Headline.
 - **Body** (400 weight, 0.875rem, lh 1.6): All prose, descriptions, note content. Max line length 65ch.
 - **Label** (500 weight, 0.75rem, lh 1.4, ls +0.01em): Input labels, tags, stat captions, tab text. Slightly tracked for legibility at small sizes.
-- **Eyebrow Label** (600 weight, `10px`, uppercase, ls `0.1em`, muted): Section eyebrow — the small all-caps label placed above a dominant number. In Tailwind: `text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground`. Never competes with the number it names. Use 9px / `tracking-[0.08em]` for sub-eyebrows inside compact cells.
+- **Eyebrow Label** (600 weight, `10px`, uppercase, ls `0.1em`, muted): Section eyebrow — the small all-caps label placed above a dominant number. In Tailwind: `text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground`. Never competes with the number it names. Use 9px / `tracking-[0.08em]` for sub-eyebrows inside compact cells. Context can be appended with a centered-dot separator: `Cashflow · MAGGIO 2026` — the `·` joins without adding another label.
+- **Delta Annotation** (Geist Mono, 400 weight, `12px`, ls 0): The small trend line that appears directly below a sub-hero value inside a KPI chip — e.g. `+5.2% vs mese scorso`. Always `font-mono`. Color follows sign semantics: `text-green-500 dark:text-green-400` for positive, `text-red-500 dark:text-red-400` for negative. **Inverted semantics for expense metrics**: a positive delta on Spese is bad; parameter the color via `positiveGood: boolean`. In Tailwind: `text-[12px] font-mono mt-1.5 text-green-500 dark:text-green-400`. A neutral subline (non-trend) uses `text-[12px] text-muted-foreground mt-1.5`.
 - **Numeric** (Geist Mono, 400 weight, 0.875rem, lh 1.4, `font-feature-settings: "tnum" 1`): All monetary values, percentages, dates, quantities in financial contexts. Tabular figures always enabled.
 
 ### Named Rules
@@ -495,9 +496,32 @@ The pattern for smooth expand/collapse of a section that has variable or unknown
 
 ### Muted Sub-tile
 
-A tinted grid item used inside a collapsible or compact section to present multiple KPIs in a `grid-cols-2` or `grid-cols-4` layout. This is the only permitted departure from flat `divide-y` rows when a compact grid layout is needed.
+A tinted grid item for compact KPI grids. Two variants exist for different contexts.
 
-**Structure:**
+#### Variant A — KPI Chip (prominent, borderless)
+
+Used in persistent full-width sections where the metrics are the primary content (e.g. the cashflow KPI row). Background is semi-transparent so it reads as a zone without visual heaviness.
+
+```tsx
+<div className="bg-muted/40 rounded-xl p-3.5">
+  <p className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground mb-1.5">
+    Label
+  </p>
+  <p className="text-[22px] font-bold font-mono tabular-nums text-foreground leading-none">
+    Value
+  </p>
+  <p className="text-[12px] font-mono mt-1.5 text-muted-foreground">
+    Secondary / delta line
+  </p>
+</div>
+```
+
+Grid: `grid grid-cols-2 desktop:grid-cols-4 gap-3`. Value scale: Sub-hero (`text-[22px]`). Delta annotation uses the **Delta Annotation** typographic level (sign-aware color).
+
+#### Variant B — Parameter Tile (dense, bordered)
+
+Used inside collapsible sections where slight extra separation aids readability of many parameters side by side.
+
 ```tsx
 <div className="bg-muted rounded-xl p-3.5 border border-border">
   <p className="text-[9.5px] font-semibold uppercase tracking-[0.08em] text-muted-foreground mb-1.5">
@@ -507,10 +531,100 @@ A tinted grid item used inside a collapsible or compact section to present multi
 </div>
 ```
 
+**Shared rules:**
+- Background is `bg-muted/40` (Variant A) or `bg-muted` (Variant B) — never `bg-card` (card-within-card violation).
+- Radius is `rounded-xl` (14px), one step below the container's `rounded-2xl`.
+- Variant A (KPI chip): use for persistent, always-visible metrics. No border — the background tint alone provides definition.
+- Variant B (parameter tile): use inside collapsible parameter panels only. The border adds precision in high-density config grids.
+
+### Thin Category Bar
+
+A minimal inline progress bar for category breakdowns inside a KPI card. Shows proportional weight at a glance without mounting a full chart component.
+
+**Structure:**
+```tsx
+<div className="space-y-3">
+  {categories.map(cat => (
+    <div key={cat.name} className="space-y-1">
+      <div className="flex justify-between items-center">
+        <div className="flex items-center gap-2 min-w-0">
+          {/* Dot indicator — circle, always rounded-full */}
+          <div className="w-2 h-2 rounded-full flex-shrink-0" style={{ background: color }} />
+          <span className="text-[13px] text-foreground truncate">{cat.name}</span>
+        </div>
+        <span className="text-[13px] font-mono tabular-nums text-foreground ml-3 flex-shrink-0">
+          {formattedValue}
+        </span>
+      </div>
+      {/* Bar track */}
+      <div className="h-[3px] bg-muted rounded-full overflow-hidden">
+        <div className="h-full rounded-full" style={{ width: `${cat.percentage}%`, background: color }} />
+      </div>
+    </div>
+  ))}
+</div>
+```
+
 **Rules:**
-- Background is `bg-muted` (tinted, never `bg-card` — that would be a card-within-card violation).
-- Radius is `rounded-xl` (14px), one step smaller than the containing card's `rounded-2xl`.
-- Use only inside collapsible sections where the grid provides scan-order clarity. Do not use as a persistent visible element on the page.
+- Bar height is exactly `3px` — an accent shape, not the primary data carrier. Category name and value carry the data; the bar adds scannable shape.
+- Color from `useChartColors()` via the parent — never hardcoded hex. Expense categories use `chartColors[0]`; income categories use `chartColors[1]`.
+- Row dot indicator uses `rounded-full` (circle). Contrast this with the chart legend swatch below, which uses `rounded-[2px]` (square) — circles mean "inline indicator," squares mean "color key."
+- Use `truncate` on the category name with `min-w-0` on the flex parent to prevent overflow on long names.
+- Only render the entire block when data is available (`categories.length > 0`) — no placeholder bars with dummy widths.
+- Two-column layout inside a card: expenses left, income right via `grid desktop:grid-cols-2 gap-x-8 gap-y-4`. On mobile they stack.
+
+### Card Sticky Footer
+
+A technique for pinning secondary metric content to the bottom of a variable-height Card. Used when optional data (TER, costs) should align to the card baseline regardless of how much primary content is above it.
+
+**Implementation:**
+```tsx
+<Card className="rounded-2xl overflow-hidden h-full">
+  <CardContent className="p-[22px] flex flex-col h-full">
+    {/* Primary content — fills available space naturally */}
+    <p className="eyebrow">...</p>
+    <div className="value">...</div>
+    {/* Sticky footer — pushed to the bottom via mt-auto */}
+    {hasOptionalData && (
+      <div className="mt-auto pt-4 border-t border-border">
+        {/* secondary metrics */}
+      </div>
+    )}
+  </CardContent>
+</Card>
+```
+
+**Rules:**
+- Requires `flex flex-col h-full` on `CardContent` and `h-full` on `Card`. Without both, `mt-auto` collapses.
+- The containing grid row must also define a height (`h-full` propagates from the row in `desktop:grid-cols-[2fr_1fr]`). On mobile where the grid stacks, each card determines its own height naturally.
+- Use only for **optional/conditional** secondary content. Footer content that always renders should be placed at a fixed spacing from the primary block, not anchored via `mt-auto`.
+- `border-t border-border` provides visual separation; `pt-4` provides breathing room. `mt-auto` creates the push — no explicit `flex-1` spacer element needed.
+- On desktop, pair with the companion card's `h-full` so the sticky footer visually aligns with the companion card's bottom edge.
+
+### Chart Legend Swatch
+
+The color swatch used in pie chart legend rows. At 8×8px, shape matters: a fully round circle reads as a "dot indicator" (inline traffic-light semantics); a slightly rounded square reads as a "color key."
+
+**Structure (LegendRow):**
+```tsx
+<div className="flex items-center gap-2">
+  {/* Square swatch — rounded-[2px], NOT rounded-full */}
+  <div
+    className="w-2 h-2 rounded-[2px] flex-shrink-0"
+    style={{ background: item.color || chartColors[index] }}
+  />
+  <span className="flex-1 text-[11.5px] text-foreground font-medium truncate">{item.name}</span>
+  <span className="text-[11.5px] text-muted-foreground font-mono tabular-nums">
+    {item.percentage.toFixed(1)}%
+  </span>
+</div>
+```
+
+**Rules:**
+- `rounded-[2px]` for legend swatches (color keys). `rounded-full` for inline dot indicators (category bars, status bullets).
+- Filter legend rows to `percentage >= 5` — slices below 5% don't warrant a label at the available width.
+- Value shown is `percentage` (not raw currency) — the chart slice already communicates proportion; the legend reinforces it numerically.
+- Container: `flex flex-col gap-[7px]` with `min-w-0` to handle truncation of long asset names.
 
 ### Deferred Chart Mount (Performance Pattern)
 
@@ -557,6 +671,11 @@ useEffect(() => {
 - **Do** use `-mx-[N]px` negative margin (matching the card padding) to create edge-to-edge charts inside a card — `preserveAspectRatio="none"` on the SVG fills the broken-out container correctly.
 - **Do** use `desktop:grid-cols-[2fr_1fr]` for the primary hero+companion layout at the top of a page. The asymmetric ratio communicates hierarchy through space, not just typography.
 - **Do** use `border-t border-border/40 pt-4` for section separators within a page scroll flow. The 40% opacity is lighter than structural borders — it suggests chapter, not division.
+- **Do** use `bg-muted/40 rounded-xl p-3.5` (no border) for KPI chip grids inside persistent, always-visible sections. Reserve the full-opacity `bg-muted` with `border border-border` for parameter tiles in collapsible zones.
+- **Do** use `mt-auto` inside `flex flex-col h-full` CardContent to pin optional secondary content to the card bottom. The pattern requires `h-full` on both Card and CardContent; without both, `mt-auto` has no space to push against.
+- **Do** use `rounded-[2px]` for chart legend color swatches (color keys). Use `rounded-full` for inline dot indicators (row bullets, status dots). The distinction is semantic: square = color key, circle = inline marker.
+- **Do** duplicate responsive blocks with `desktop:hidden` / `hidden desktop:grid` when the same data must be positioned differently across breakpoints (e.g. TER + cost metrics in the hero card footer on desktop, as standalone cards below the hero on mobile). Redundant DOM is preferable to a convoluted single implementation that degrades at both sizes.
+- **Do** use inverted sign semantics (parameterized `positiveGood: boolean`) for expense delta annotations. A positive Spese delta means spending increased — the color should be red, opposite to the income logic. Never hardcode green-for-positive in components that handle both income and expense metrics.
 
 ### Don't:
 
@@ -578,3 +697,6 @@ useEffect(() => {
 - **Don't** use a Recharts `<ResponsiveContainer>` in compact pie chart mode when the width is known. Pass `width` and `height` directly to `<PieChart>` to avoid the "width: -1" warning and prevent layout reflows during animation.
 - **Don't** place count-up animation logic (`useCountUp`, `rAF` loops) in a page-level component. Every frame tick re-renders the entire tree. Animation state belongs in a dedicated leaf component.
 - **Don't** render a ring or donut chart with `strokeLinecap="round"` when the segment can be near 0% or near 100% — the round caps visually overlap the track ring and distort the reading. Use `strokeLinecap="butt"` for data-accurate arcs.
+- **Don't** use `rounded-full` for pie chart legend swatches. At 8×8px, a circle reads as a traffic-light dot (status indicator), not as a color key. `rounded-[2px]` reads as a color sample. The distinction is visually meaningful.
+- **Don't** use an animated SVG donut or ring chart when flat `divide-y` rows carry the same information more clearly. Chrome reduction is the primary principle — the animated donut in the Liquid card was replaced by a flat 3-row breakdown precisely because the breakdown communicates more (three separate values, individual percentages) with less visual noise.
+- **Don't** use placeholder bars (e.g. dummy `width: 0` category bars) when no data is available. Omit the block entirely — absence communicates "no data" more cleanly than empty chrome.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -22,7 +22,13 @@ I due riferimenti sono complementari: condividono dark mode premium, tipografia 
 
 **Visual tone**: Ultra-clean con personalità. Spazio intenzionale. Gerarchia tipografica netta. Dati che respirano. Animazioni che informano, non intrattengono.
 
-**Layout vocabulary**: La pagina Panoramica definisce il vocabolario di layout per tutte le pagine. Hero asimmetrico `[2fr_1fr]` in cima (numero dominante + contesto); riga bento secondaria `grid-cols-3` per KPI di pari peso; sezioni secondarie collassabili (Radix Collapsible + Framer Motion height:auto) per non sovraccaricare la fold; separatori `border-t border-border/40` tra capitoli. I grafici sono deferiti via `requestIdleCallback` fino al completamento dell'animazione hero, per non competere sul frame budget.
+**Layout vocabulary**: La pagina Panoramica definisce il vocabolario di layout per tutte le pagine:
+- **Hero asimmetrico** `desktop:grid-cols-[2fr_1fr]` in cima: numero dominante a sinistra, card di contesto (breakdown patrimoniale) a destra. L'asimmetria 2:1 comunica gerarchia attraverso lo spazio, non solo la tipografia.
+- **KPI Chip Grid** full-width: sotto l'hero, una sezione a larghezza piena con `grid grid-cols-2 desktop:grid-cols-4 gap-3` di sub-tile `bg-muted/40 rounded-xl`. Quattro metriche di pari peso (Entrate / Spese / Risparmio / Rapporto) con sub-hero value `text-[22px]` + delta annotation `text-[12px] font-mono`. Seguita da category bar breakdown.
+- **Card Sticky Footer**: l'hero card usa `flex flex-col h-full` + `mt-auto` per ancorare il blocco TER/Costo al fondo della card, visivamente allineato col bordo inferiore della companion card.
+- **Responsive duplication**: i blocchi TER/Costo compaiono sia nel footer dell'hero card (desktop, `hidden desktop:grid`) sia come standalone `grid-cols-2` sotto l'hero (mobile, `desktop:hidden`). Lo stesso dato, due posizioni diverse — preferibile alla logica condizionale convoluta.
+- **Sezioni secondarie** collassabili (Radix Collapsible + Framer Motion height:auto) per non sovraccaricare la fold.
+- **Separatori** `border-t border-border/40` tra capitoli. I grafici sono deferiti via `requestIdleCallback` fino al completamento dell'animazione hero, per non competere sul frame budget.
 
 **Direzione**: Overdrive — implementazioni tecnicamente ambiziose che fanno alzare il sopracciglio. Fisica spring su dialog, scroll-driven reveals, counter animati, sparkline edge-to-edge con gradiente, donut SVG animato con `motion.circle`, transizioni che sembrano impossibili per una web app.
 
@@ -32,7 +38,7 @@ I due riferimenti sono complementari: condividono dark mode premium, tipografia 
 
 ### Design Principles
 
-1. **Dati prima, chrome mai** — ogni elemento visivo guadagna il suo spazio comunicando un'informazione. Se togliendolo la pagina è più chiara, va tolto. Box decorative, progress bar estetiche, divisori ridondanti: fuori.
+1. **Dati prima, chrome mai** — ogni elemento visivo guadagna il suo spazio comunicando un'informazione. Se togliendolo la pagina è più chiara, va tolto. Box decorative, progress bar estetiche, divisori ridondanti: fuori. Il donut SVG animato nella Liquid card è stato sostituito da un semplice breakdown flat a 3 righe — tre valori espliciti comunicano più di una forma geometrica animata.
 
 2. **Il numero comanda** — il dato primario di ogni schermata occupa il massimo spazio fisico e visivo disponibile. Gerarchia Trade Republic: valore in `text-[44px] desktop:text-[54px] font-bold font-mono` per hero di pagina, `text-[36px]` per hero di sezione, `text-[22px]` per valori secondari accoppiati. Eyebrow label `text-[10px] uppercase tracking-[0.1em]` sopra il numero. Variazione come chip `text-[15px] font-semibold font-mono rounded-[9px] px-[13px] py-[6px]` sotto il numero. L'utente capisce il numero più importante in meno di 2 secondi, senza cercare.
 

--- a/app/dashboard/assets/page.tsx
+++ b/app/dashboard/assets/page.tsx
@@ -87,7 +87,7 @@ function CashAccountsSection({
             type="button"
             onClick={() => onSelect(asset)}
             className={cn(
-              'cursor-pointer rounded-xl border border-border bg-card p-4 text-left',
+              'cursor-pointer rounded-xl border border-border bg-card p-5 text-left',
               'hover:bg-muted/50 active:bg-muted/70 transition-colors duration-150',
               'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1'
             )}
@@ -319,8 +319,9 @@ export default function AssetsPage() {
   return (
     <div className="space-y-6 max-desktop:portrait:pb-20">
       {/* ── PAGE HEADER ── */}
-      <div>
-        <h1 className="text-2xl font-bold text-foreground">Patrimonio</h1>
+      <div className="border-b border-border pb-4">
+        <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">Portfolio</p>
+        <h1 className="mt-1 text-2xl font-bold text-foreground sm:text-3xl">Patrimonio</h1>
         <p className="mt-2 text-muted-foreground">Gestisci e monitora il tuo patrimonio</p>
       </div>
 

--- a/app/dashboard/cashflow/page.tsx
+++ b/app/dashboard/cashflow/page.tsx
@@ -24,7 +24,7 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { useQueryClient } from '@tanstack/react-query';
-import { Wallet, Receipt, Coins, BarChart3, Target, Layers } from 'lucide-react';
+import { Receipt, Coins, BarChart3, Target, Layers } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ExpenseTrackingTab } from '@/components/cashflow/ExpenseTrackingTab';
@@ -163,12 +163,11 @@ export default function CashflowPage() {
   };
 
   return (
-    <div className="space-y-6 p-4 desktop:p-8 max-desktop:portrait:pb-20">
+    <div className="space-y-6 max-desktop:portrait:pb-20">
       {/* Header */}
       <div className="border-b border-border pb-4">
         <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">Operatività</p>
-        <h1 className="mt-1 flex items-center gap-2 text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
-          <Wallet className="h-7 w-7 text-primary sm:h-8 sm:w-8" />
+        <h1 className="mt-1 text-2xl font-bold text-foreground sm:text-3xl">
           Cashflow
         </h1>
         <p className="mt-2 text-muted-foreground">
@@ -205,7 +204,7 @@ export default function CashflowPage() {
                       {activeTab === value && (
                         <motion.span
                           layoutId="cashflow-mobile-tab"
-                          className="absolute inset-0 rounded-lg bg-background shadow-sm"
+                          className="absolute inset-0 rounded-lg bg-card shadow-sm"
                           transition={{ type: 'spring', stiffness: 400, damping: 35 }}
                         />
                       )}

--- a/components/assets/AssetManagementTab.tsx
+++ b/components/assets/AssetManagementTab.tsx
@@ -461,7 +461,7 @@ export function AssetManagementTab({ assets, allAssets, loading, onRefresh, snap
       </div>
 
       <Card>
-        <CardContent>
+        <CardContent className="p-0">
           {assets.length === 0 ? (
             <div className="flex h-64 flex-col items-center justify-center gap-3 text-muted-foreground">
               <Wallet className="h-10 w-10 opacity-30" />
@@ -562,7 +562,7 @@ export function AssetManagementTab({ assets, allAssets, loading, onRefresh, snap
                         const isPending = pendingDeleteId === asset.id;
                         const perf = assetPerformanceData[asset.id];
                         return (
-                          <TableRow key={asset.id} className={isManualPrice ? 'bg-amber-50 dark:bg-amber-950/20' : ''}>
+                          <TableRow key={asset.id} className={isManualPrice ? 'bg-[color-mix(in_oklch,var(--chart-3)_6%,transparent)]' : ''}>
                             <TableCell className="font-medium max-w-[180px]">
                               <div className="flex items-center gap-2 min-w-0">
                                 <TooltipProvider>
@@ -653,9 +653,9 @@ export function AssetManagementTab({ assets, allAssets, loading, onRefresh, snap
                                   const isPos = gainLoss > 0;
                                   const isNeg = gainLoss < 0;
                                   const textColor = isPos
-                                    ? 'text-green-600'
+                                    ? 'text-green-600 dark:text-green-400'
                                     : isNeg
-                                    ? 'text-red-600'
+                                    ? 'text-red-600 dark:text-red-400'
                                     : 'text-muted-foreground';
                                   return (
                                     <div className={`${textColor} font-medium tabular-nums`}>

--- a/components/cashflow/ExpenseTrackingTab.tsx
+++ b/components/cashflow/ExpenseTrackingTab.tsx
@@ -90,11 +90,12 @@ const getExpenseDate = (d: Expense['date']): Date => {
 };
 
 // Tailwind dot-color classes keyed by expense type for the mobile list rows.
+// Uses CSS variable references so they stay theme-aware across all 6 colour themes.
 const TYPE_DOT_CLASS: Record<ExpenseType, string> = {
-  income: 'bg-green-500',
-  fixed: 'bg-blue-500',
-  variable: 'bg-purple-500',
-  debt: 'bg-orange-500',
+  income: 'bg-green-500 dark:bg-green-400',
+  fixed: 'bg-[var(--chart-2)]',
+  variable: 'bg-[var(--chart-4)]',
+  debt: 'bg-[var(--chart-3)]',
 };
 
 // ─── MobileExpenseRow ─────────────────────────────────────────────────────────
@@ -797,17 +798,9 @@ export function ExpenseTrackingTab({ allExpenses, categories, loading, onRefresh
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-2xl font-bold tracking-tight">
-            {selectedMonth !== 'all' ? `${MONTHS.find(m => m.value === selectedMonth)?.label} ` : ''}{selectedYear}
-          </h2>
-          <p className="text-muted-foreground mt-0.5 text-sm">
-            Gestisci le tue entrate e uscite
-          </p>
-        </div>
-        <Button onClick={handleAddExpense} disabled={isDemo} title={isDemo ? 'Non disponibile in modalità demo' : undefined} className="hidden desktop:flex">
+      {/* Desktop "Nuova Spesa" button — mobile uses FAB below */}
+      <div className="hidden desktop:flex justify-end">
+        <Button onClick={handleAddExpense} disabled={isDemo} title={isDemo ? 'Non disponibile in modalità demo' : undefined}>
           <Plus className="mr-2 h-4 w-4" />
           Nuova Spesa
         </Button>

--- a/components/expenses/ExpenseTable.tsx
+++ b/components/expenses/ExpenseTable.tsx
@@ -229,18 +229,21 @@ export function ExpenseTable({ expenses, onEdit, onRefresh, isDemo = false }: Ex
     return EXPENSE_TYPE_LABELS[type];
   };
 
+  // Badge colors keyed by expense type — theme-aware via CSS variable references.
+  // chart-1: income (green-toned in most themes), chart-2: fixed, chart-4: variable, chart-3: debt.
+  // color-mix() at 12% for background, 35% for border; text uses the raw chart var directly.
   const getTypeBadgeColor = (type: ExpenseType): string => {
     switch (type) {
       case 'income':
-        return 'bg-green-100 text-green-800 border-green-200 dark:bg-green-950/40 dark:text-green-400 dark:border-green-800';
+        return 'bg-[color-mix(in_oklch,var(--chart-1)_12%,transparent)] border-[color-mix(in_oklch,var(--chart-1)_35%,transparent)] text-[var(--chart-1)]';
       case 'fixed':
-        return 'bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-950/40 dark:text-blue-400 dark:border-blue-800';
+        return 'bg-[color-mix(in_oklch,var(--chart-2)_12%,transparent)] border-[color-mix(in_oklch,var(--chart-2)_35%,transparent)] text-[var(--chart-2)]';
       case 'variable':
-        return 'bg-purple-100 text-purple-800 border-purple-200 dark:bg-purple-950/40 dark:text-purple-400 dark:border-purple-800';
+        return 'bg-[color-mix(in_oklch,var(--chart-4)_12%,transparent)] border-[color-mix(in_oklch,var(--chart-4)_35%,transparent)] text-[var(--chart-4)]';
       case 'debt':
-        return 'bg-orange-100 text-orange-800 border-orange-200 dark:bg-orange-950/40 dark:text-orange-400 dark:border-orange-800';
+        return 'bg-[color-mix(in_oklch,var(--chart-3)_12%,transparent)] border-[color-mix(in_oklch,var(--chart-3)_35%,transparent)] text-[var(--chart-3)]';
       default:
-        return 'bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-700';
+        return 'bg-muted border-border text-muted-foreground';
     }
   };
 
@@ -415,7 +418,9 @@ export function ExpenseTable({ expenses, onEdit, onRefresh, isDemo = false }: Ex
               <TableCell className="text-right font-medium">
                 <div
                   className={`flex items-center justify-end gap-1 ${
-                    expense.type === 'income' ? 'text-green-600' : 'text-red-600'
+                    expense.type === 'income'
+                      ? 'text-green-600 dark:text-green-400'
+                      : 'text-red-600 dark:text-red-400'
                   }`}
                 >
                   {expense.type === 'income' ? (
@@ -442,7 +447,7 @@ export function ExpenseTable({ expenses, onEdit, onRefresh, isDemo = false }: Ex
                     href={expense.link}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center justify-center text-blue-600 hover:text-blue-800"
+                    className="inline-flex items-center justify-center text-primary hover:text-primary/70 transition-colors"
                     title="Apri link"
                   >
                     <ExternalLink className="h-4 w-4" />

--- a/docs/audit-prompts.md
+++ b/docs/audit-prompts.md
@@ -176,13 +176,20 @@ File: app/dashboard/page.tsx
 Componenti: components/dashboard/*
 
 Assi da verificare:
-- Token: nessun `bg-gray-*`/`dark:bg-*`/hex hardcoded nei KPI cards, sparkline wrapper,
-  cashflow summary, savings rate badge
-- Chart colors: `NetWorthSparkline` e tutti i chart via `useChartColors()`
-- Gerarchia: hero patrimonio `text-4xl font-bold font-mono`, KPI secondary come flat rows
-- Breakpoint: `md:` → `desktop:`, griglia KPI corretta su portrait tablet
-- Skeleton: `OverviewAnimatedCurrency` e `OverviewChartsSection` hanno skeleton strutturale
-- Motion: `requestIdleCallback` per chart mount, `useCountUp` con `once: true`
+- Token: nessun `bg-gray-*`/`dark:bg-*`/hex hardcoded in hero card, liquid card,
+  KPI chip grid (`bg-muted/40`), category bars, TER/Costo cards (mobile), charts section
+- Chart colors: `NetWorthSparkline` usa `color="var(--chart-1)"` (non hex); tutti i
+  chart di composizione via `useChartColors()`; category bar colors da `chartColors[0/1]`
+- Gerarchia: hero `text-[44px] desktop:text-[54px] font-bold font-mono`; liquid card
+  `text-[36px]`; KPI chip `text-[22px]`; delta annotation `text-[12px] font-mono`
+- Muted sub-tile: KPI chips usano `bg-muted/40` (no border) — non `bg-muted border-border`
+  (quello è per parameter tiles nei collapsible)
+- Breakpoint: `md:` → `desktop:`; KPI grid `grid-cols-2 desktop:grid-cols-4`; TER/Costo
+  responsive duplication (`desktop:hidden` su mobile row, `hidden desktop:grid` nel hero footer)
+- Skeleton: `OverviewAnimatedCurrency` isolato in leaf, `OverviewChartsSection` memoized;
+  skeleton inline strutturalmente isomorfo al layout v2 (hero 2fr+1fr, KPI grid 4-col)
+- Motion: `requestIdleCallback` per chart mount; `useCountUp` `once: true`; `heroSettled`
+  → `chartRenderReady` handoff; card-tab `layoutId="chart-tab"` unico nella pagina
 
 Contesto:
 - Leggi AGENTS.md (pattern, convenzioni, gotcha)
@@ -193,46 +200,32 @@ Contesto:
 
 ## Patrimonio
 
-### Tab "Gestione Asset"
-
 ```
-/impeccable audit il tab "Gestione Asset" della pagina Patrimonio
+/impeccable audit la pagina Patrimonio
 
 File: app/dashboard/assets/page.tsx
 Componenti: components/assets/AssetManagementTab.tsx,
             components/assets/AssetCard.tsx,
             components/assets/AssetMobileSummary.tsx,
             components/assets/AssetSparkline.tsx,
-            components/assets/AssetDialog.tsx
+            components/assets/AssetDialog.tsx,
+            components/dashboard/OverviewAnimatedCurrency.tsx,
+            components/dashboard/NetWorthSparkline.tsx
 
-Assi da verificare:
-- Token: nessun hardcoded nei badge classe asset, nei valori G/P (usa `text-emerald-*`?
-  → deve essere CSS var o `color-mix()`), nei separatori
-- Chart colors: `AssetSparkline` via `useChartColors()`
-- Gerarchia: valore asset dominante, G/P secondary — nessun card-in-card in AssetCard
-- Breakpoint: tabella ordinabile visibile solo `desktop:`, `AssetMobileSummary` solo portrait
-- ARIA: delete 2-click ha `aria-label` e timeout di disarmo visibile
-- Skeleton: struttura skeleton isomorfa alla lista reale (stessa altezza righe)
-
-Contesto:
-- Leggi AGENTS.md (pattern, convenzioni, gotcha)
-- Leggi CLAUDE.md (stato corrente, known issues)
-```
-
-### Tab "Anno Corrente" e "Storico"
-
-```
-/impeccable audit i tab "Anno Corrente" e "Storico" della pagina Patrimonio
-
-File: app/dashboard/assets/page.tsx
-Componenti: components/assets/AssetPriceHistoryTable.tsx,
-            components/assets/AssetClassHistoryTable.tsx
-
-Assi da verificare:
-- Token: nessun hardcoded nelle tabelle — header, celle, badge "Venduto"
-- Breakpoint: scroll orizzontale su mobile gestito correttamente (non rompe il layout)
-- ARIA: tabelle con `<caption>` o `aria-label`, header `<th scope="col">`
-- Badge "Venduto": colore via CSS var o `color-mix()`, non hardcoded
+La pagina è una singola scroll — nessun tab. Assi da verificare:
+- Token: hero card e liquid card (condivisi con Panoramica) — nessun hardcoded;
+  CashAccountsSection card grid — nessun `bg-gray-*`; badge classe asset,
+  valori G/P (`color-mix()` non `text-emerald-*`) — nessun hardcoded
+- Gerarchia: hero `text-[44px]/[54px]`; liquid card `text-[36px]`; flat 3-row
+  breakdown con `w-[42px] text-right` per i %; G/P non realizzato come riga border-t
+- Chart colors: `NetWorthSparkline` usa `var(--chart-1)`; `AssetSparkline` via
+  `useChartColors()`
+- CashAccountsSection: `bg-muted/40` (KPI chip variant, no border) — nessun `bg-card`
+  (sarebbe card-in-card); grid `grid-cols-2 desktop:grid-cols-4`
+- AssetManagementTab: tabella ordinabile solo `desktop:`, `AssetMobileSummary` solo
+  portrait; delete 2-click con `aria-label` e disarmo visibile; skeleton isomorfo
+- ARIA: AssetDialog con `DialogDescription`; type picker Step 1 con `role="radio"`
+- Breakpoint: `md:` → `desktop:`; `max-desktop:portrait:pb-20`
 
 Contesto:
 - Leggi AGENTS.md (pattern, convenzioni, gotcha)

--- a/docs/critique-prompts.md
+++ b/docs/critique-prompts.md
@@ -22,10 +22,18 @@ no card-in-card, `useChartColors()` per tutte le serie grafiche, token complianc
 File: app/dashboard/page.tsx
 Componenti: components/dashboard/*
 
-Questa è la home del dashboard: mostra il patrimonio netto in tempo reale
-con sparkline 12 mesi, KPI cards (liquidità, investimenti, costi), variazioni
-periodiche e un riepilogo cashflow con savings rate.
-Confronta con: Rendimenti (hero TWR), Storico (hero patrimonio), Goals (hero allocato).
+Questa è la home del dashboard — layout "Bento Asimmetrico v2":
+- Hero [2fr_1fr]: Patrimonio Totale Lordo (text-[44px]/[54px]) + sparkline 12m
+  edge-to-edge (-mx-[22px]) + variation chips; Liquid card con breakdown flat
+  a 3 righe (Liquidità / Investimenti Liquidabili / Illiquidi) + sezione Impatto
+  Fiscale condizionale. Hero card usa Card Sticky Footer (mt-auto) per TER+Costo su desktop.
+- TER + Costo Annuale: responsive duplication (desktop:hidden / hidden desktop:grid).
+- Cashflow card (full-width): 4 KPI chip (bg-muted/40 rounded-xl, text-[22px]) con
+  delta annotation text-[12px] font-mono + category bar breakdown (h-[3px], 2-col).
+- Charts section: deferred via requestIdleCallback; tab-switched su mobile (layoutId
+  "chart-tab"), 2-col grid su desktop; legend swatch rounded-[2px].
+Confronta con: Patrimonio (stesso hero [2fr_1fr]), Rendimenti (hero TWR),
+Storico (hero patrimonio), Goals (hero allocato).
 Design language atteso: Trade Republic hierarchy (text-4xl font-bold font-mono hero,
 divide-y flat rows, no card-in-card), useChartColors() per tutte le serie grafiche,
 token compliance su tutti e 6 i temi dell'app.
@@ -45,75 +53,30 @@ servirà come input per il prossimo step:
 
 ## Patrimonio
 
-### Tab "Gestione Asset"
-
 ```
-/impeccable critique il tab "Gestione Asset" della pagina Patrimonio
+/impeccable critique la pagina Patrimonio
 
 File: app/dashboard/assets/page.tsx
 Componenti: components/assets/AssetManagementTab.tsx,
             components/assets/AssetCard.tsx,
             components/assets/AssetMobileSummary.tsx,
             components/assets/AssetSparkline.tsx,
-            components/assets/AssetDialog.tsx
+            components/assets/AssetDialog.tsx,
+            components/dashboard/OverviewAnimatedCurrency.tsx,
+            components/dashboard/NetWorthSparkline.tsx
 
-Questo tab mostra la lista degli asset correnti con add/edit/delete inline,
-sparkline per asset, tabella ordinabile su desktop e AssetMobileSummary
-(ultimi 3 mesi) su mobile. AssetDialog ha un 2-step creation flow.
-Confronta con: AllocationCard (flat divide-y), GoalDetailCard (expand/collapse inline).
-Design language atteso: Trade Republic hierarchy (text-4xl font-bold font-mono hero,
-divide-y flat rows, no card-in-card), useChartColors() per tutte le serie grafiche,
-token compliance su tutti e 6 i temi dell'app.
-
-Contesto:
-- Leggi AGENTS.md (pattern, convenzioni, gotcha)
-- Leggi CLAUDE.md (stato corrente, known issues)
-
-Al termine indica il path esatto del file .impeccable/critique/[slug].md generato —
-servirà come input per il prossimo step:
-- Solo P2/P3 → /impeccable polish (legge il file automaticamente)
-- P0/P1 presenti → /impeccable shape prima, poi /impeccable polish dopo l'implementazione
-- P0/P1 + P2/P3 → shape prima (P0/P1), implementa, poi polish (P2/P3) — i P2/P3 aspettano
-```
-
-### Tab "Anno Corrente"
-
-```
-/impeccable critique il tab "Anno Corrente" della pagina Patrimonio
-
-File: app/dashboard/assets/page.tsx
-Componenti: components/assets/AssetPriceHistoryTable.tsx
-
-Questo tab mostra le tabelle storiche dei prezzi per l'anno in corso,
-filtrate su asset con quantity > 0 (nessun asset venduto).
-Confronta con: Storico (history page, narrative order), Hall of Fame (tabelle flat).
-Design language atteso: Trade Republic hierarchy (text-4xl font-bold font-mono hero,
-divide-y flat rows, no card-in-card), useChartColors() per tutte le serie grafiche,
-token compliance su tutti e 6 i temi dell'app.
-
-Contesto:
-- Leggi AGENTS.md (pattern, convenzioni, gotcha)
-- Leggi CLAUDE.md (stato corrente, known issues)
-
-Al termine indica il path esatto del file .impeccable/critique/[slug].md generato —
-servirà come input per il prossimo step:
-- Solo P2/P3 → /impeccable polish (legge il file automaticamente)
-- P0/P1 presenti → /impeccable shape prima, poi /impeccable polish dopo l'implementazione
-- P0/P1 + P2/P3 → shape prima (P0/P1), implementa, poi polish (P2/P3) — i P2/P3 aspettano
-```
-
-### Tab "Storico"
-
-```
-/impeccable critique il tab "Storico" della pagina Patrimonio
-
-File: app/dashboard/assets/page.tsx
-Componenti: components/assets/AssetClassHistoryTable.tsx,
-            components/assets/AssetPriceHistoryTable.tsx
-
-Questo tab mostra lo storico completo degli asset inclusi quelli venduti
-(quantity === 0, badge "Venduto"). restrictToPassedAssets è attivo su entrambe le tabelle.
-Confronta con: Storico (history page, tabelle con dati storici), Hall of Fame (tabelle flat).
+La pagina è una singola scroll (nessun tab). Layout:
+- Header
+- Hero [2fr_1fr]: identico a Panoramica — stesso `useDashboardOverview` RQ cache,
+  stessa variazione chips, stessa sparkline edge-to-edge, stessa Liquid card
+  con flat 3-row breakdown. In più: riga G/P non realizzato condizionale.
+- CashAccountsSection: grid cards 2-col/4-col per i conti correnti (type=cash,
+  assetClass=cash), esclusi dalla tabella principale.
+- AssetManagementTab: tabella ordinabile (Valore, G/P%, Peso%, Nome, Classe),
+  group-by-class toggle, sparkline per asset, 2-click delete, AssetDialog 2-step.
+  Mobile: AssetMobileSummary (ultimi 3 mesi).
+Confronta con: Panoramica (stesso hero layout), AllocationCard (flat divide-y),
+GoalDetailCard (expand/collapse inline).
 Design language atteso: Trade Republic hierarchy (text-4xl font-bold font-mono hero,
 divide-y flat rows, no card-in-card), useChartColors() per tutte le serie grafiche,
 token compliance su tutti e 6 i temi dell'app.
@@ -735,9 +698,9 @@ Dalla meno redesignata alla più redesignata, per trovare i delta maggiori prima
 4. Impostazioni ← redesign parziale
 5. Landing Page ← primo contatto utente, mai critiquata
 6. Login e Register ← già migliorati ma mai critiquati formalmente
-7. Panoramica ← molte feature aggiunte incrementalmente
-8. Patrimonio (3 tab) ← redesignata ma con tab separati da verificare singolarmente
-9. Cashflow / tab "Tracciamento" e "Budget" ← da verificare dopo AnalisiTab
+7. Panoramica ← v2 con KPI chip grid + category bars (verifica delta)
+8. Patrimonio ← pagina unica (nessun tab), hero condiviso con Panoramica
+9. Cashflow / tab "Tracciamento" (mobileLabel: "Spese") e "Budget" ← da verificare dopo AnalisiTab
 10. Allocazione
 11. Rendimenti
 12. Storico

--- a/docs/polish-prompts.md
+++ b/docs/polish-prompts.md
@@ -37,10 +37,8 @@ Contesto:
 
 ## Patrimonio
 
-### Tab "Gestione Asset"
-
 ```
-/impeccable polish il tab "Gestione Asset" della pagina Patrimonio
+/impeccable polish la pagina Patrimonio
 
 Priority issues (P2/P3) da: [SLUG]
 File: app/dashboard/assets/page.tsx
@@ -48,40 +46,9 @@ Componenti: components/assets/AssetManagementTab.tsx,
             components/assets/AssetCard.tsx,
             components/assets/AssetMobileSummary.tsx,
             components/assets/AssetSparkline.tsx,
-            components/assets/AssetDialog.tsx
-
-Contesto:
-- Leggi AGENTS.md (pattern, convenzioni, gotcha)
-- Leggi CLAUDE.md (stato corrente, known issues)
-- Leggi COMMENTS.md e APPLICALA mentre scrivi codice
-- Leggi DEVELOPMENT_GUIDELINES.md e APPLICALA mentre scrivi codice
-```
-
-### Tab "Anno Corrente"
-
-```
-/impeccable polish il tab "Anno Corrente" della pagina Patrimonio
-
-Priority issues (P2/P3) da: [SLUG]
-File: app/dashboard/assets/page.tsx
-Componenti: components/assets/AssetPriceHistoryTable.tsx
-
-Contesto:
-- Leggi AGENTS.md (pattern, convenzioni, gotcha)
-- Leggi CLAUDE.md (stato corrente, known issues)
-- Leggi COMMENTS.md e APPLICALA mentre scrivi codice
-- Leggi DEVELOPMENT_GUIDELINES.md e APPLICALA mentre scrivi codice
-```
-
-### Tab "Storico"
-
-```
-/impeccable polish il tab "Storico" della pagina Patrimonio
-
-Priority issues (P2/P3) da: [SLUG]
-File: app/dashboard/assets/page.tsx
-Componenti: components/assets/AssetClassHistoryTable.tsx,
-            components/assets/AssetPriceHistoryTable.tsx
+            components/assets/AssetDialog.tsx,
+            components/dashboard/OverviewAnimatedCurrency.tsx,
+            components/dashboard/NetWorthSparkline.tsx
 
 Contesto:
 - Leggi AGENTS.md (pattern, convenzioni, gotcha)
@@ -132,7 +99,7 @@ Contesto:
 - Leggi DEVELOPMENT_GUIDELINES.md e APPLICALA mentre scrivi codice
 ```
 
-### Tab "Tracciamento"
+### Tab "Tracciamento" *(mobileLabel: "Spese")*
 
 ```
 /impeccable polish il tab "Tracciamento" della pagina Cashflow

--- a/docs/shape-prompts.md
+++ b/docs/shape-prompts.md
@@ -24,7 +24,8 @@ Priority issues (P0/P1) da: [SLUG]
 File: app/dashboard/page.tsx
 Componenti: components/dashboard/*
 
-Confronta con: Rendimenti (hero TWR), Storico (hero patrimonio), Goals (hero allocato).
+Confronta con: Patrimonio (stesso hero [2fr_1fr] condiviso), Rendimenti (hero TWR),
+Storico (hero patrimonio), Goals (hero allocato).
 Design language atteso: Trade Republic hierarchy (text-4xl font-bold font-mono hero,
 divide-y flat rows, no card-in-card), useChartColors() per tutte le serie grafiche,
 token compliance su tutti e 6 i temi dell'app.
@@ -40,10 +41,8 @@ Contesto:
 
 ## Patrimonio
 
-### Tab "Gestione Asset"
-
 ```
-/impeccable shape il tab "Gestione Asset" della pagina Patrimonio
+/impeccable shape la pagina Patrimonio
 
 Priority issues (P0/P1) da: [SLUG]
 File: app/dashboard/assets/page.tsx
@@ -51,52 +50,16 @@ Componenti: components/assets/AssetManagementTab.tsx,
             components/assets/AssetCard.tsx,
             components/assets/AssetMobileSummary.tsx,
             components/assets/AssetSparkline.tsx,
-            components/assets/AssetDialog.tsx
+            components/assets/AssetDialog.tsx,
+            components/dashboard/OverviewAnimatedCurrency.tsx,
+            components/dashboard/NetWorthSparkline.tsx
 
-Confronta con: AllocationCard (flat divide-y), GoalDetailCard (expand/collapse inline).
-Design language atteso: Trade Republic hierarchy (text-4xl font-bold font-mono hero,
-divide-y flat rows, no card-in-card), useChartColors() per tutte le serie grafiche,
-token compliance su tutti e 6 i temi dell'app.
-
-Contesto:
-- Leggi AGENTS.md (pattern, convenzioni, gotcha)
-- Leggi CLAUDE.md (stato corrente, known issues)
-- Leggi COMMENTS.md e APPLICALA mentre scrivi codice
-- Leggi DEVELOPMENT_GUIDELINES.md e APPLICALA mentre scrivi codice
-```
-
-### Tab "Anno Corrente"
-
-```
-/impeccable shape il tab "Anno Corrente" della pagina Patrimonio
-
-Priority issues (P0/P1) da: [SLUG]
-File: app/dashboard/assets/page.tsx
-Componenti: components/assets/AssetPriceHistoryTable.tsx
-
-Confronta con: Storico (history page), Hall of Fame (tabelle flat).
-Design language atteso: Trade Republic hierarchy (text-4xl font-bold font-mono hero,
-divide-y flat rows, no card-in-card), useChartColors() per tutte le serie grafiche,
-token compliance su tutti e 6 i temi dell'app.
-
-Contesto:
-- Leggi AGENTS.md (pattern, convenzioni, gotcha)
-- Leggi CLAUDE.md (stato corrente, known issues)
-- Leggi COMMENTS.md e APPLICALA mentre scrivi codice
-- Leggi DEVELOPMENT_GUIDELINES.md e APPLICALA mentre scrivi codice
-```
-
-### Tab "Storico"
-
-```
-/impeccable shape il tab "Storico" della pagina Patrimonio
-
-Priority issues (P0/P1) da: [SLUG]
-File: app/dashboard/assets/page.tsx
-Componenti: components/assets/AssetClassHistoryTable.tsx,
-            components/assets/AssetPriceHistoryTable.tsx
-
-Confronta con: Storico (history page), Hall of Fame (tabelle flat).
+Pagina unica (nessun tab): Header → Hero [2fr_1fr] (identico a Panoramica,
+condivide useDashboardOverview RQ cache) → CashAccountsSection (grid cards
+conti correnti) → AssetManagementTab (tabella ordinabile, group-by-class,
+sparkline per asset, 2-click delete, AssetDialog 2-step).
+Confronta con: Panoramica (stesso hero layout — usa come riferimento primario),
+AllocationCard (flat divide-y), GoalDetailCard (expand/collapse inline).
 Design language atteso: Trade Republic hierarchy (text-4xl font-bold font-mono hero,
 divide-y flat rows, no card-in-card), useChartColors() per tutte le serie grafiche,
 token compliance su tutti e 6 i temi dell'app.
@@ -160,7 +123,7 @@ Contesto:
 - Leggi DEVELOPMENT_GUIDELINES.md e APPLICALA mentre scrivi codice
 ```
 
-### Tab "Tracciamento"
+### Tab "Tracciamento" *(mobileLabel: "Spese")*
 
 ```
 /impeccable shape il tab "Tracciamento" della pagina Cashflow


### PR DESCRIPTION
…trimonio and Cashflow

- docs: update DESIGN.md with 7 new patterns extracted from Overview v2 redesign (KPI Chip Grid variants A/B, Delta Annotation, Thin Category Bar, Card Sticky Footer, Chart Legend Swatch, Eyebrow separator, responsive duplication do/don'ts)
- docs: update PRODUCT.md layout vocabulary to name new layout primitives explicitly
- docs: update audit/critique/shape/polish prompt files to reflect Patrimonio as single-scroll page (no tabs) and Cashflow 'Tracciamento' mobileLabel 'Spese'

Patrimonio (app/dashboard/assets/page.tsx, components/assets/AssetManagementTab.tsx):
- Add eyebrow 'Portfolio' + border-b separator to page header; add sm:text-3xl
- CashAccountsSection card padding p-4 → p-5
- CardContent missing className='p-0' on asset table card
- Manual-price TableRow highlight: bg-amber-50 dark:bg-amber-950/20 → bg-[color-mix(in_oklch,var(--chart-3)_6%,transparent)] (theme-aware)
- G/P column text colors: text-green-600/text-red-600 → add dark:text-green-400/ dark:text-red-400 for dark mode readability

Cashflow (app/dashboard/cashflow/page.tsx, components/cashflow/ExpenseTrackingTab.tsx,
          components/expenses/ExpenseTable.tsx):
- Remove extra p-4 desktop:p-8 from page container (was double-padding with layout.tsx)
- Remove Wallet icon and tracking-tight from h1; clean up unused Wallet import
- Mobile active tab pill: bg-background → bg-card (pill is now visually distinct against bg-muted track in dark mode)
- TYPE_DOT_CLASS mobile dots: bg-blue-500/bg-purple-500/bg-orange-500 → bg-[var(--chart-2)]/bg-[var(--chart-4)]/bg-[var(--chart-3)] (theme-aware CSS vars)
- Remove redundant h2 date heading + subtitle from ExpenseTrackingTab return; keep desktop 'Nuova Spesa' button in clean hidden desktop:flex wrapper
- ExpenseTable getTypeBadgeColor: replace all hardcoded blue/purple/orange/gray + dark variants with color-mix(in_oklch, var(--chart-N) 12%/35%, transparent) pattern
- ExpenseTable amount column: add dark:text-green-400/dark:text-red-400 variants
- ExpenseTable external link: text-blue-600 hover:text-blue-800 → text-primary hover:text-primary/70 (follows theme accent color)