### PR TITLE
fix: require Firebase auth on public price endpoints (SEC-1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Net Worth Tracker is a Next.js app for Italian investors to track net worth, ass
 
 ## Current Status
 - Stack: Next.js 16, React 19, TypeScript 5, Tailwind v4, Firebase, Vitest, Framer Motion, Recharts, Yahoo Finance, Borsa Italiana scraping, Anthropic
-- Latest (2026-06-10): **Security review — spec di implementazione in `docs/security-review-spec.md`**. Full static security review (API routes, firestore.rules, secrets, XSS, SSRF/scraping, input validation, HTTP headers, deps, AI endpoints, logging) — no code changes. Outcome: overall posture good (centralized auth helper used by 25/30 routes, default-deny rules, no XSS, no secrets in git — the "committed .env.local" agent report was a verified false positive). 8 findings (SEC-1..SEC-8, 1 high: `/api/prices/quote` + `/api/prices/bond-quote` public without auth), each spec'd with implementation steps, acceptance criteria, required tests and a copy-paste prompt for weaker models; one PR per finding into `develop`, order SEC-1→2→3→5→4→8→6→7. The spec also codifies the session-close ritual (pre-commit confirmation, `SESSION_NOTES.md` Cosa/Perché/Nota entry, post-merge doc-update ritual).
+- Latest (2026-06-10): **SEC-1 implementato** — `GET /api/prices/quote` e `GET /api/prices/bond-quote` ora richiedono autenticazione Firebase (`requireFirebaseAuth`); `AssetDialog` aggiornato a `authenticatedFetch`; 4 test aggiunti in `apiAuthRoutes.test.ts`. Security review completa in `docs/security-review-spec.md` (8 findings, SEC-1 ✅, SEC-2..8 pending); ordine SEC-2→3→5→4→8→6→7.
 
 ## Architecture Snapshot
 - App Router with protected pages under `app/dashboard/*`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Net Worth Tracker is a Next.js app for Italian investors to track net worth, ass
 
 ## Current Status
 - Stack: Next.js 16, React 19, TypeScript 5, Tailwind v4, Firebase, Vitest, Framer Motion, Recharts, Yahoo Finance, Borsa Italiana scraping, Anthropic
-- Latest (2026-06-10): **SEC-1 implementato** — `GET /api/prices/quote` e `GET /api/prices/bond-quote` ora richiedono autenticazione Firebase (`requireFirebaseAuth`); `AssetDialog` aggiornato a `authenticatedFetch`; 4 test aggiunti in `apiAuthRoutes.test.ts`. Security review completa in `docs/security-review-spec.md` (8 findings, SEC-1 ✅, SEC-2..8 pending); ordine SEC-2→3→5→4→8→6→7.
+- Latest (2026-06-10): **SEC-1 implemented** — `GET /api/prices/quote` and `GET /api/prices/bond-quote` now require Firebase auth (`requireFirebaseAuth`); `AssetDialog` migrated to `authenticatedFetch`; 4 tests added in `apiAuthRoutes.test.ts`. Full security review in `docs/security-review-spec.md` (8 findings, SEC-1 ✅, SEC-2..8 pending); order SEC-2→3→5→4→8→6→7.
 
 ## Architecture Snapshot
 - App Router with protected pages under `app/dashboard/*`

--- a/Draft Release Temp.md
+++ b/Draft Release Temp.md
@@ -155,3 +155,7 @@
 - **Portfolio asset table is less cramped on laptops** — the ticker now appears under each asset's name instead of taking its own column, and the three performance columns (Δ this month / year-to-date / since start) are hidden behind a new "Andamento" toggle in the table toolbar, so the default table fits without scrolling sideways at common laptop widths. Turn the toggle on whenever you want the full performance breakdown. All figures in the table are now in a monospaced font for cleaner column alignment
 - **Portfolio summary card is calmer** — the liquid-wealth summary card's heading now names the exact figure it shows ("Patrimonio Liquidabile Netto"), and the detailed "Impatto Fiscale" tax breakdown is collapsed by default, expandable with a tap
 - **"Andamento Strumenti Selezionati" now explains *why* a value moved** — on the Storico "Valore per Strumento" chart, hovering a month now shows the change versus the previous month split into "da prezzo" (market movement) and "da quantità" (your buys and sells). So when a holding's line drops, you can tell at a glance whether the market fell or you simply sold part of the position — instead of guessing
+
+## 🔒 Security
+
+- Price quote endpoints (Yahoo Finance and Borsa Italiana) now require authentication, preventing unauthorized use as open proxies

--- a/__tests__/apiAuthRoutes.test.ts
+++ b/__tests__/apiAuthRoutes.test.ts
@@ -27,6 +27,8 @@ const {
   snapshotDocSetMock,
   overviewSummaryDocGetMock,
   overviewSummaryDocSetMock,
+  getQuoteMock,
+  getBondPriceByIsinMock,
 } = vi.hoisted(() => ({
   verifyIdTokenMock: vi.fn(),
   getAllDividendsMock: vi.fn(),
@@ -45,6 +47,8 @@ const {
   snapshotDocSetMock: vi.fn(),
   overviewSummaryDocGetMock: vi.fn(),
   overviewSummaryDocSetMock: vi.fn(),
+  getQuoteMock: vi.fn(),
+  getBondPriceByIsinMock: vi.fn(),
 }));
 
 vi.mock('@/lib/firebase/admin', () => ({
@@ -145,6 +149,14 @@ vi.mock('@/lib/helpers/priceUpdater', () => ({
   updateUserAssetPrices: updateUserAssetPricesMock,
 }));
 
+vi.mock('@/lib/services/yahooFinanceService', () => ({
+  getQuote: getQuoteMock,
+}));
+
+vi.mock('@/lib/services/borsaItalianaBondScraperService', () => ({
+  getBondPriceByIsin: getBondPriceByIsinMock,
+}));
+
 // Use importOriginal so any new exports from assetService are included automatically.
 // Only override the functions whose return values matter for the route tests.
 vi.mock('@/lib/services/assetService', async (importOriginal) => {
@@ -178,6 +190,8 @@ vi.mock('@/lib/utils/dateHelpers', async () => {
 import { GET as getDividendsRoute } from '@/app/api/dividends/route';
 import { DELETE as deleteDividendRoute } from '@/app/api/dividends/[dividendId]/route';
 import { POST as updatePricesRoute } from '@/app/api/prices/update/route';
+import { GET as priceQuoteRoute } from '@/app/api/prices/quote/route';
+import { GET as bondQuoteRoute } from '@/app/api/prices/bond-quote/route';
 import { POST as snapshotRoute } from '@/app/api/portfolio/snapshot/route';
 import { GET as dashboardOverviewRoute } from '@/app/api/dashboard/overview/route';
 import { POST as invalidateDashboardOverviewRoute } from '@/app/api/dashboard/overview/invalidate/route';
@@ -461,6 +475,67 @@ describe('Private API route auth', () => {
       }),
       { merge: true }
     );
+  });
+
+  it('returns 401 for price quote route without Authorization header', async () => {
+    const response = await priceQuoteRoute(
+      createJsonRequest('http://localhost/api/prices/quote?ticker=AAPL')
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Missing Authorization bearer token',
+    });
+    expect(getQuoteMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 for price quote route with valid token', async () => {
+    getQuoteMock.mockResolvedValue({
+      ticker: 'AAPL',
+      price: 200,
+      currency: 'USD',
+    });
+
+    const response = await priceQuoteRoute(
+      createJsonRequest('http://localhost/api/prices/quote?ticker=AAPL', {
+        headers: { Authorization: 'Bearer valid-token' },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(verifyIdTokenMock).toHaveBeenCalledWith('valid-token');
+    expect(getQuoteMock).toHaveBeenCalledWith('AAPL');
+  });
+
+  it('returns 401 for bond quote route without Authorization header', async () => {
+    const response = await bondQuoteRoute(
+      createJsonRequest('http://localhost/api/prices/bond-quote?isin=IT0005672024')
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Missing Authorization bearer token',
+    });
+    expect(getBondPriceByIsinMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 for bond quote route with valid token', async () => {
+    getBondPriceByIsinMock.mockResolvedValue({
+      isin: 'IT0005672024',
+      price: 98.5,
+      currency: 'EUR',
+      priceType: 'ultimo',
+    });
+
+    const response = await bondQuoteRoute(
+      createJsonRequest('http://localhost/api/prices/bond-quote?isin=IT0005672024', {
+        headers: { Authorization: 'Bearer valid-token' },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(verifyIdTokenMock).toHaveBeenCalledWith('valid-token');
+    expect(getBondPriceByIsinMock).toHaveBeenCalledWith('IT0005672024');
   });
 
   it('allows snapshot creation for cron callers using cronSecret without Firebase auth', async () => {

--- a/app/api/prices/bond-quote/route.ts
+++ b/app/api/prices/bond-quote/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getBondPriceByIsin } from '@/lib/services/borsaItalianaBondScraperService';
+import { getApiAuthErrorResponse, requireFirebaseAuth } from '@/lib/server/apiAuth';
 
 /**
  * GET /api/prices/bond-quote?isin=IT0005672024
@@ -22,6 +23,8 @@ import { getBondPriceByIsin } from '@/lib/services/borsaItalianaBondScraperServi
  */
 export async function GET(request: NextRequest) {
   try {
+    await requireFirebaseAuth(request);
+
     const searchParams = request.nextUrl.searchParams;
     const isin = searchParams.get('isin');
 
@@ -37,6 +40,9 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json(result);
   } catch (error) {
+    const authResponse = getApiAuthErrorResponse(error);
+    if (authResponse) return authResponse;
+
     console.error('Error in bond-quote API:', error);
     return NextResponse.json(
       {

--- a/app/api/prices/quote/route.ts
+++ b/app/api/prices/quote/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getQuote } from '@/lib/services/yahooFinanceService';
 import { convertToEur } from '@/lib/services/currencyConversionService';
+import { getApiAuthErrorResponse, requireFirebaseAuth } from '@/lib/server/apiAuth';
 
 /**
  * GET /api/prices/quote
@@ -26,6 +27,8 @@ import { convertToEur } from '@/lib/services/currencyConversionService';
  */
 export async function GET(request: NextRequest) {
   try {
+    await requireFirebaseAuth(request);
+
     const searchParams = request.nextUrl.searchParams;
     const ticker = searchParams.get('ticker');
 
@@ -64,6 +67,9 @@ export async function GET(request: NextRequest) {
       ...(currentPriceEur !== undefined ? { currentPriceEur } : {}),
     });
   } catch (error) {
+    const authResponse = getApiAuthErrorResponse(error);
+    if (authResponse) return authResponse;
+
     console.error('Error fetching quote:', error);
     return NextResponse.json(
       { error: 'Failed to fetch quote' },

--- a/components/assets/AssetDialog.tsx
+++ b/components/assets/AssetDialog.tsx
@@ -126,10 +126,10 @@ async function fetchMarketPrice(
     let source: string;
 
     if (isBondWithIsin) {
-      response = await fetch(`/api/prices/bond-quote?isin=${encodeURIComponent(isin!.trim())}`);
+      response = await authenticatedFetch(`/api/prices/bond-quote?isin=${encodeURIComponent(isin!.trim())}`);
       source = 'Borsa Italiana';
     } else {
-      response = await fetch(`/api/prices/quote?ticker=${encodeURIComponent(ticker)}`);
+      response = await authenticatedFetch(`/api/prices/quote?ticker=${encodeURIComponent(ticker)}`);
       source = 'Yahoo Finance';
     }
 

--- a/docs/security-review-spec.md
+++ b/docs/security-review-spec.md
@@ -16,7 +16,7 @@ I problemi trovati sono mirati e tutti risolvibili con interventi contenuti:
 
 | ID | Finding | Severità | Effort | PR suggerita |
 |----|---------|----------|--------|--------------|
-| SEC-1 | Endpoint prezzi pubblici senza autenticazione (proxy aperto verso Yahoo Finance / Borsa Italiana) | **ALTA** | S | `fix/sec-1-auth-price-endpoints` |
+| SEC-1 | Endpoint prezzi pubblici senza autenticazione (proxy aperto verso Yahoo Finance / Borsa Italiana) | **ALTA** | S | ✅ implementato — branch `fix/sec-1-auth-price-endpoints` |
 | SEC-2 | Confronto `CRON_SECRET` non timing-safe (3 punti) | MEDIA | S | `fix/sec-2-timing-safe-cron-secret` |
 | SEC-3 | Nessuna validazione server-side dei body/query (zod installato ma inutilizzato lato server); ISIN interpolato in URL senza validazione | MEDIA | M | `fix/sec-3-server-input-validation` |
 | SEC-4 | Nessun security header HTTP (CSP, HSTS, X-Frame-Options, ecc.) | MEDIA | S | `fix/sec-4-security-headers` |


### PR DESCRIPTION
## Summary

- `GET /api/prices/quote` and `GET /api/prices/bond-quote` were unauthenticated — anyone could use the deployment as a free proxy to Yahoo Finance and Borsa Italiana scraper
- Added `requireFirebaseAuth` + `getApiAuthErrorResponse` to both routes (same pattern as `app/api/dividends/route.ts`)
- Migrated the two `fetch()` calls in `AssetDialog.tsx` to `authenticatedFetch` (import was already present)
- No `assertSameUser` needed — market data routes, only authentication is required

## Changes

- `app/api/prices/quote/route.ts` — auth guard added
- `app/api/prices/bond-quote/route.ts` — auth guard added
- `components/assets/AssetDialog.tsx` — two `fetch()` → `authenticatedFetch()`
- `__tests__/apiAuthRoutes.test.ts` — 4 new tests (401 without header, 200 with valid token, for each route)

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test -- __tests__/apiAuthRoutes.test.ts` — 14/14 pass
- [x] `curl 'http://localhost:3000/api/prices/quote?ticker=AAPL'` without auth → 401
- [x] `curl 'http://localhost:3000/api/prices/bond-quote?isin=IT0005672024'` without auth → 401
- [x] Edit existing ETF asset (remove manual price, save) → price fetched correctly from Yahoo Finance
- [x] Edit existing bond asset (remove manual price, save) → price fetched correctly from Borsa Italiana

🤖 Generated with [Claude Code](https://claude.com/claude-code)