### PR TITLE
Extract FX conversion to shared util; apply EUR conversion to benchmark hero

### DIFF
--- a/__tests__/benchmarkPeriodReturn.test.ts
+++ b/__tests__/benchmarkPeriodReturn.test.ts
@@ -7,9 +7,11 @@ import { describe, it, expect } from 'vitest';
 import {
   buildIndexedSeries,
   annualizeTWR,
+  applyFxConversion,
   computeBenchmarkAnnualizedReturn,
   type MonthlyReturnPoint,
 } from '@/lib/utils/benchmarkPeriodReturn';
+import type { FxMonthlyRate } from '@/types/benchmarks';
 
 const series: MonthlyReturnPoint[] = [
   { year: 2024, month: 11, return: 0.05 }, // outside a 2025 window
@@ -44,6 +46,25 @@ describe('annualizeTWR', () => {
 
   it('should return null for non-positive months', () => {
     expect(annualizeTWR(110, 0)).toBeNull();
+  });
+});
+
+describe('applyFxConversion', () => {
+  // 1 USD = 1.00 EUR in Jan, 1.10 EUR in Feb → USD strengthened 10% vs EUR.
+  const fx: FxMonthlyRate[] = [
+    { year: 2025, month: 1, eurPerUsd: 1.0 },
+    { year: 2025, month: 2, eurPerUsd: 1.1 },
+  ];
+
+  it('should fold the FX move into the EUR return', () => {
+    const usd: MonthlyReturnPoint[] = [{ year: 2025, month: 2, return: 0.05 }];
+    // (1.05) * (1.10 / 1.00) - 1 = 0.155
+    expect(applyFxConversion(usd, fx)[0].return).toBeCloseTo(0.155, 10);
+  });
+
+  it('should pass a month through unchanged when FX data is missing', () => {
+    const usd: MonthlyReturnPoint[] = [{ year: 2025, month: 1, return: 0.05 }]; // no prior month rate
+    expect(applyFxConversion(usd, fx)[0].return).toBe(0.05);
   });
 });
 

--- a/app/dashboard/performance/page.tsx
+++ b/app/dashboard/performance/page.tsx
@@ -58,8 +58,9 @@ import { authenticatedFetch } from '@/lib/utils/authFetch';
 import { PageContainer } from '@/components/layout/PageContainer';
 import { PageHeader } from '@/components/layout/PageHeader';
 import { useBenchmarkReturns } from '@/lib/hooks/useBenchmarkReturns';
+import { useFxRates } from '@/lib/hooks/useFxRates';
 import { BENCHMARKS } from '@/lib/constants/benchmarks';
-import { computeBenchmarkAnnualizedReturn } from '@/lib/utils/benchmarkPeriodReturn';
+import { computeBenchmarkAnnualizedReturn, applyFxConversion } from '@/lib/utils/benchmarkPeriodReturn';
 import {
   summarizePerformance,
   computeBenchmarkDelta,
@@ -286,6 +287,11 @@ export default function PerformancePage() {
   const referenceBenchmark = BENCHMARKS[0];
   const { data: referenceBenchmarkReturns, isLoading: isBenchmarkLoading } =
     useBenchmarkReturns(referenceBenchmark.id, true);
+  // The portfolio TWR is EUR-denominated, so the hero must compare it against an
+  // EUR-converted benchmark — otherwise the delta mixes currencies (the benchmark's
+  // USD return vs an EUR portfolio). Always fetch FX so the chip matches the comparison
+  // table's "Converti benchmark in EUR" view, not its USD default.
+  const { data: fxRates, isLoading: isFxLoading } = useFxRates(true);
 
   // Responsive breakpoints
   const isMobile = useMediaQuery('(max-width: 767px)');
@@ -583,13 +589,19 @@ export default function PerformancePage() {
   // math as the comparison table (shared util) so the hero delta matches the table exactly.
   const benchmarkAnnualized = useMemo(() => {
     if (!metrics || !referenceBenchmarkReturns) return null;
+    // Convert the benchmark's native (USD) returns to EUR before annualizing, mirroring
+    // the comparison table's FX logic so hero and table report the same number.
+    const eurReturns =
+      fxRates && fxRates.length > 0
+        ? applyFxConversion(referenceBenchmarkReturns, fxRates)
+        : referenceBenchmarkReturns;
     return computeBenchmarkAnnualizedReturn(
-      referenceBenchmarkReturns,
+      eurReturns,
       metrics.startDate,
       metrics.endDate,
       metrics.numberOfMonths
     );
-  }, [metrics, referenceBenchmarkReturns]);
+  }, [metrics, referenceBenchmarkReturns, fxRates]);
 
   const benchmarkDelta = computeBenchmarkDelta(metrics?.timeWeightedReturn ?? null, benchmarkAnnualized);
   const performanceVerdict = metrics
@@ -867,7 +879,7 @@ export default function PerformancePage() {
           verdict={performanceVerdict}
           benchmarkLabel={referenceBenchmark.name}
           benchmarkDelta={benchmarkDelta}
-          benchmarkLoading={isBenchmarkLoading}
+          benchmarkLoading={isBenchmarkLoading || isFxLoading}
           drawdown={drawdownStatus}
           sharpeRatio={metrics.sharpeRatio}
           maxDrawdown={metrics.maxDrawdown}

--- a/components/performance/BenchmarkComparisonChart.tsx
+++ b/components/performance/BenchmarkComparisonChart.tsx
@@ -16,7 +16,7 @@ import { MonthlyReturnHeatmapData } from '@/types/performance';
 import { useChartColors } from '@/lib/hooks/useChartColors';
 // Indexing + annualization live in a shared pure util so the hero's "vs benchmark"
 // delta uses the exact same math as this table (no rounding drift).
-import { buildIndexedSeries, annualizeTWR } from '@/lib/utils/benchmarkPeriodReturn';
+import { buildIndexedSeries, annualizeTWR, applyFxConversion } from '@/lib/utils/benchmarkPeriodReturn';
 
 interface BenchmarkComparisonChartProps {
   // User portfolio monthly returns (from prepareMonthlyReturnsHeatmap)
@@ -83,38 +83,6 @@ function flattenHeatmap(heatmapData: MonthlyReturnHeatmapData[]): Array<{ year: 
     }
   }
   return flat.sort((a, b) => a.year !== b.year ? a.year - b.year : a.month - b.month);
-}
-
-/**
- * Convert a USD monthly return series to EUR using end-of-month FX rates.
- *
- * Formula: R_EUR[t] = (1 + R_USD[t]) * (eurPerUsd[t] / eurPerUsd[t-1]) - 1
- *
- * Months where the FX rate is unavailable are passed through unchanged (USD return).
- */
-function applyFxConversion(
-  returns: Array<{ year: number; month: number; return: number }>,
-  fxRates: FxMonthlyRate[]
-): Array<{ year: number; month: number; return: number }> {
-  const fxMap = new Map<string, number>(
-    fxRates.map(r => [`${r.year}-${String(r.month).padStart(2, '0')}`, r.eurPerUsd])
-  );
-
-  return returns.map(r => {
-    const currKey = `${r.year}-${String(r.month).padStart(2, '0')}`;
-    const prevDate = new Date(r.year, r.month - 2, 1); // month - 2 because Date month is 0-indexed
-    const prevKey = `${prevDate.getFullYear()}-${String(prevDate.getMonth() + 1).padStart(2, '0')}`;
-
-    const currRate = fxMap.get(currKey);
-    const prevRate = fxMap.get(prevKey);
-
-    if (currRate == null || prevRate == null || prevRate === 0) {
-      return r; // FX data unavailable for this month — pass through unchanged
-    }
-
-    const returnEur = (1 + r.return) * (currRate / prevRate) - 1;
-    return { ...r, return: returnEur };
-  });
 }
 
 /**

--- a/components/performance/PerformanceHero.tsx
+++ b/components/performance/PerformanceHero.tsx
@@ -161,7 +161,7 @@ export function PerformanceHero({
           {drawdown && (
             <span className="inline-flex items-center gap-1 rounded-full border border-border bg-muted/40 px-2.5 py-1 text-xs">
               {drawdown.atPeak ? (
-                <span className="font-medium text-positive">Nuovo massimo storico</span>
+                <span className="font-medium text-positive">Massimo del periodo</span>
               ) : (
                 <>
                   <span className="text-muted-foreground">dal massimo</span>

--- a/lib/utils/benchmarkPeriodReturn.ts
+++ b/lib/utils/benchmarkPeriodReturn.ts
@@ -8,6 +8,8 @@
  * unit-tested directly.
  */
 
+import type { FxMonthlyRate } from '@/types/benchmarks';
+
 /** A single month of decimal return (e.g. 0.02 = +2%). */
 export interface MonthlyReturnPoint {
   year: number;
@@ -64,6 +66,40 @@ export function annualizeTWR(cumulativeIndexed: number, numberOfMonths: number):
   if (years === 0) return (cumulativeReturn - 1) * 100;
   const annualized = (Math.pow(cumulativeReturn, 1 / years) - 1) * 100;
   return isFinite(annualized) ? annualized : null;
+}
+
+/**
+ * Convert a USD monthly return series to EUR using end-of-month FX rates.
+ *
+ * Formula: R_EUR[t] = (1 + R_USD[t]) * (eurPerUsd[t] / eurPerUsd[t-1]) - 1
+ *
+ * Months where the FX rate is unavailable are passed through unchanged (USD return).
+ * Shared by the benchmark comparison table and the Rendimenti hero "vs benchmark" delta
+ * so both compare the EUR-denominated portfolio against an EUR-converted benchmark.
+ */
+export function applyFxConversion(
+  returns: MonthlyReturnPoint[],
+  fxRates: FxMonthlyRate[]
+): MonthlyReturnPoint[] {
+  const fxMap = new Map<string, number>(
+    fxRates.map(r => [`${r.year}-${String(r.month).padStart(2, '0')}`, r.eurPerUsd])
+  );
+
+  return returns.map(r => {
+    const currKey = `${r.year}-${String(r.month).padStart(2, '0')}`;
+    const prevDate = new Date(r.year, r.month - 2, 1); // month - 2 because Date month is 0-indexed
+    const prevKey = `${prevDate.getFullYear()}-${String(prevDate.getMonth() + 1).padStart(2, '0')}`;
+
+    const currRate = fxMap.get(currKey);
+    const prevRate = fxMap.get(prevKey);
+
+    if (currRate == null || prevRate == null || prevRate === 0) {
+      return r; // FX data unavailable for this month — pass through unchanged
+    }
+
+    const returnEur = (1 + r.return) * (currRate / prevRate) - 1;
+    return { ...r, return: returnEur };
+  });
 }
 
 /**

--- a/lib/utils/performanceSummary.ts
+++ b/lib/utils/performanceSummary.ts
@@ -194,7 +194,7 @@ export function computeReturnConsistency(
 // ---------------------------------------------------------------------------
 
 export interface DrawdownStatus {
-  /** true when the latest point is at a fresh all-time high (drawdown ~0). */
+  /** true when the latest point is at a fresh high for the selected period (drawdown ~0). */
   atPeak: boolean;
   /** Current distance below the peak, as a non-positive percentage (e.g. -3.2). */
   current: number;


### PR DESCRIPTION
## Summary
Moves the FX conversion logic from `BenchmarkComparisonChart` into a shared, tested utility (`applyFxConversion` in `benchmarkPeriodReturn.ts`) so both the benchmark comparison table and the performance hero's "vs benchmark" delta use identical EUR-conversion math. The hero now fetches FX rates and converts the reference benchmark's USD returns to EUR before annualizing, ensuring the delta chip matches the table's EUR view.

## Key Changes
- **Extract `applyFxConversion` to shared util** (`lib/utils/benchmarkPeriodReturn.ts`):
  - Moved from `BenchmarkComparisonChart.tsx` (component-local) to a pure, exported function
  - Converts USD monthly returns to EUR using end-of-month FX rates
  - Formula: `R_EUR[t] = (1 + R_USD[t]) * (eurPerUsd[t] / eurPerUsd[t-1]) - 1`
  - Passes through unchanged when FX data is unavailable
  - Added comprehensive unit tests in `__tests__/benchmarkPeriodReturn.test.ts`

- **Apply FX conversion in performance hero** (`app/dashboard/performance/page.tsx`):
  - Added `useFxRates(true)` hook call to fetch FX rates at page level
  - Convert reference benchmark returns to EUR before annualizing via `applyFxConversion`
  - Updated `benchmarkAnnualized` memo to use EUR-converted returns
  - Updated loading state to include FX loading (`isBenchmarkLoading || isFxLoading`)
  - Added explanatory comment: portfolio TWR is EUR-denominated, so hero must compare against EUR-converted benchmark to avoid currency mismatch

- **Minor UI text refinement** (`PerformanceHero.tsx`):
  - Changed "Nuovo massimo storico" → "Massimo del periodo" to reflect period-scoped drawdown logic
  - Updated `DrawdownStatus` JSDoc to clarify "fresh high for the selected period" vs all-time high

## Implementation Details
- The FX conversion logic is now DRY: both the comparison table and hero use the exact same `applyFxConversion` function, eliminating rounding drift and ensuring consistency
- FX rates are fetched asynchronously at the page level; the hero gracefully falls back to USD returns if FX data is unavailable
- All existing tests pass; new tests cover the FX conversion formula and missing-data fallback behavior

https://claude.ai/code/session_01AkfKwjLtiSSnZFsyUHtqaY