### PR TITLE
docs(pension): mark P0 complete across the spec folder

### DIFF
--- a/docs/specs/2-pension-fund/01-data-model-and-rules.md
+++ b/docs/specs/2-pension-fund/01-data-model-and-rules.md
@@ -1,5 +1,14 @@
 # 01 — Data Model, AssetType, Collection, Rules, Validation
 
+> Status: **§1-2 ✅ IMPLEMENTATE (Fase P0, 2026-07-24)** — `types/pension.ts`, `AssetType 'pensionFund'`,
+> `Asset`/`AssetFormData.pensionFundDetails`, `TYPE_TO_CLASS['pensionFund'] = 'equity'` (+ lo zod
+> enum di `assetSchema`, che duplica la union), `isLedgerAssetType('pensionFund') === false` coperto
+> da test. **§3-6 (collection `pensionContributions`, rules, indici, validazione) restano a P1.**
+> Vedi CLAUDE.md → Current Status e AGENTS.md → *Fondo Pensione — Tipi + Motore Fiscale (P0)*.
+>
+> Nota per P1: sul punto aperto di §5 (indici compositi vs sort in memoria) la raccomandazione della
+> spec — **no `orderBy`, sort in memoria** — resta quella da seguire salvo decisione contraria.
+
 ## 1. Domain types — new file `types/pension.ts`
 
 Riferimento fedele: `ciocc/main:types/pension.ts`. Riportare integralmente (i commenti TEACHER/WHY

--- a/docs/specs/2-pension-fund/02-tax-engine.md
+++ b/docs/specs/2-pension-fund/02-tax-engine.md
@@ -1,5 +1,22 @@
 # 02 — Motore fiscale (puro, testato)
 
+> Status: **✅ IMPLEMENTATA (Fase P0, 2026-07-24).** `lib/utils/pensionDeduction.ts` (§1-5, zero
+> import Firebase, `taxOf` iniettato) + `__tests__/pensionDeduction.test.ts` (§6: tutti i 18 casi
+> della matrice, più un test di invariante `isLedgerAssetType('pensionFund') === false` → 19 verdi;
+> `tsc` pulito). Nella stessa fase è stata implementata anche la **spec 01 §1-2** (`types/pension.ts`,
+> `AssetType 'pensionFund'`, `Asset/AssetFormData.pensionFundDetails`, `TYPE_TO_CLASS`); la spec 01
+> §3-6 (collection, rules, indici, validazione) resta a P1. Vedi CLAUDE.md → Current Status e
+> AGENTS.md → *Fondo Pensione — Tipi + Motore Fiscale (P0)*. Restano P1 (contributi), P2 (UI),
+> P3 (integrazioni).
+>
+> **Caveat d'uso deciso con l'owner (D-P0.2)**: i contributi storici NON vengono tracciati — si parte
+> a registrare da ora. La deduzione ordinaria (§2, path base) è per-anno e resta corretta; il fold
+> dell'extra-deducibilità invece tratta gli anni mancanti come *0 versato*, quindi accrediterebbe il
+> plafond massimo a chi ha davvero versato in passato. Perciò **`isFirstEmploymentPost2007` va tenuto
+> OFF** finché non esiste uno storico. Se in futuro servisse l'extra-deducibilità, la via è un
+> "plafond iniziale" da estratto conto — non il back-fill degli anni — e cambia la firma di
+> `PensionDeductionInput` (§2), quindi va deciso **prima di P1**.
+
 Nuovo modulo **`lib/utils/pensionDeduction.ts`** + test **`__tests__/pensionDeduction.test.ts`**.
 Riferimento fedele: `ciocc/main:lib/utils/pensionDeduction.ts` (già ottimo — riportarlo quasi
 integralmente). Vincoli: **zero import Firebase**, `taxOf` iniettato, tetti come funzione-soglia.

--- a/docs/specs/2-pension-fund/README.md
+++ b/docs/specs/2-pension-fund/README.md
@@ -1,7 +1,7 @@
 # Fondo Pensione — Specification Index
 
-> Status: **SPEC — riprogettata dal fork `Ciocc128`, adattata al branch attuale e a post
-> `asset-transactions`** (scritta 2026-07-22).
+> Status: **IN CORSO — P0 ✅ implementata (2026-07-24); P1-P3 da fare.** Spec riprogettata dal fork
+> `Ciocc128`, adattata al branch attuale e a post `asset-transactions` (scritta 2026-07-22).
 > Deliverable: tracciare il fondo pensione complementare come asset a valutazione manuale, con
 > contributi in collection dedicata, motore fiscale (deducibilità ordinaria + extra-deducibilità),
 > vista Previdenza dedicata, e integrazione con Allocazione / Storico / Rendimenti / FIRE.
@@ -37,11 +37,23 @@ Vedi anche `docs/specs/README.md` → *Decisioni di riconciliazione condivise*.
    extra-deducibilità come fold pluriennale (accumulo primi 5 anni / drawdown anni 6–25 / scadenza).
    Beneficio IRPEF via `tax(RAL) − tax(RAL − dedotto)`, riusando gli scaglioni Coast FIRE con `taxOf`
    iniettato. Campo **RAL** in Impostazioni.
+   - **D-P0.2 (fissata 2026-07-24)**: i contributi **storici non si tracciano** — si registra da ora
+     in poi. La deduzione ordinaria resta corretta (è per-anno); il fold invece legge gli anni
+     mancanti come *0 versato*, quindi **`isFirstEmploymentPost2007` va tenuto OFF** finché non
+     esiste uno storico, altrimenti il plafond risulta gonfiato. Niente UI di import storico in
+     P1/P2. Un eventuale ripensamento passa da un "plafond iniziale" da estratto conto (cambia la
+     firma di `PensionDeductionInput`) → **da decidere prima di P1**.
 7. **Casa della feature**: **vista dedicata `/dashboard/pension`** in `planningNav`, con link dalla
    card asset in Patrimonio. NON un tab in `fire-simulations`.
 8. **FIRE**: toggle `respectPensionLockInFire` — quando on, il valore dei fondi bloccati
    (`unlockDate` futura) esce dal `currentNetWorth` del calcolo FIRE (resta nel patrimonio totale).
    Coast FIRE terza gamba e withdrawal netto asset-aware = **fuori scope v1** (fase 2).
+9. **D-P0.1 (fissata 2026-07-24) — i fondi già a portafoglio si CONVERTONO, non si ricreano**: chi
+   tracciava già il fondo lo ha come `etf`/`stock` con il valore in `quantity` a prezzo 1, cioè la
+   forma esatta di destinazione. Si cambia il tipo dall'edit di `AssetDialog`; eliminare e ricreare
+   perde lo storico (`MonthlySnapshot.byAsset` è keyed by `assetId`). Attenzione al **BUY baseline
+   orfano** del registro operazioni, che `computeInvestedCapital` conterebbe ancora. Procedura,
+   conseguenze e le due opzioni di fix in `04-ui-and-views.md` §1.1 (scope P2, non opzionale).
 
 ## Glossario
 
@@ -85,7 +97,7 @@ Vedi anche `docs/specs/README.md` → *Decisioni di riconciliazione condivise*.
 
 | Fase | Scope | Gate |
 | --- | --- | --- |
-| **P0** | Tipi (`types/pension.ts`, `AssetType 'pensionFund'`, `Asset.pensionFundDetails`) + motore fiscale puro + test (spec 01 §1-2 + spec 02) | `tsc` + `vitest run __tests__/pensionDeduction.test.ts` |
+| **P0** ✅ | Tipi (`types/pension.ts`, `AssetType 'pensionFund'`, `Asset.pensionFundDetails`) + motore fiscale puro + test (spec 01 §1-2 + spec 02) — **fatta 2026-07-24**, 19 test verdi, `tsc` pulito | `tsc` + `vitest run __tests__/pensionDeduction.test.ts` |
 | **P1** | Collection `pensionContributions` + rules + indici + service (effetto valore/transfer + storno) + hooks + rollup puro + test (spec 01 §3-5 + spec 03) | `tsc` + suite contributi + rules/indexes deploy note |
 | **P2** | UI base: AssetDialog `pensionFund` (+ composition), `PensionContributionDialog`, vista `/dashboard/pension` con contributi + recap fiscale (spec 04 §1-4) | `tsc` + script test manuale |
 | **P3** | Integrazioni: Allocazione `frozen` + card look-through, segmento Storico, base Rendimenti, FIRE lock-in (spec 04 §5-8) + docs (spec 05) | `tsc` + suite aree + test manuale |


### PR DESCRIPTION
02-tax-engine is fully implemented; 01-data-model-and-rules only in part (sections 1-2 shipped with the engine, 3-6 belong to P1), so each file states its own scope rather than the folder claiming a single status. Follows the 1-asset-transactions convention of a Status blockquote under the H1, including its form for partial files.

Also records the two decisions taken while implementing P0, in the index next to the other "do not relitigate" ones, because both change what P1 and P2 are allowed to assume:
- D-P0.1: a fund already tracked as an etf/stock is converted by editing its type, never deleted and recreated, since snapshots are keyed by assetId.
- D-P0.2: historical contributions are not tracked, so isFirstEmploymentPost2007 stays off — the fold reads missing years as zero contributed and would credit an inflated plafond. This removes the historical-import UI from P1/P2 scope.