### PR TITLE
Rendimenti: i flussi seguono la base

### DIFF
--- a/__tests__/drawdownSeries.test.ts
+++ b/__tests__/drawdownSeries.test.ts
@@ -154,3 +154,21 @@ describe('findMaxDrawdown', () => {
     expect(findMaxDrawdown(index).value).toBeCloseTo(0, 10);
   });
 });
+
+describe('buildTwrIndex con una base non positiva', () => {
+  function nw(year: number, month: number, totalNetWorth: number) {
+    return {
+      userId: 'user-1', year, month, totalNetWorth,
+      liquidNetWorth: totalNetWorth, illiquidNetWorth: 0,
+      byAssetClass: {}, byAsset: [], assetAllocation: {},
+      createdAt: new Date(year, month - 1, 28),
+    } as never;
+  }
+
+  it('tiene l\'indice fermo invece di ribaltarne il segno', () => {
+    const index = buildTwrIndex([nw(2026, 1, 1000), nw(2026, 2, -500), nw(2026, 3, 1200)], []);
+
+    expect(index.every((point) => Number.isFinite(point.value))).toBe(true);
+    expect(index[2].value).toBe(index[1].value);
+  });
+});

--- a/__tests__/performanceNarrative.test.ts
+++ b/__tests__/performanceNarrative.test.ts
@@ -332,19 +332,38 @@ describe('describeConsistency', () => {
 });
 
 describe('describeContributions', () => {
+  const ledger = { flowSource: 'cashflow' as const };
+
   it('sets the ledger beside the cashflow', () => {
-    const r = describeContributions({ invested: { investedEur: 16700, divestedEur: 2500, netInvestedEur: 14200 }, netCashFlow: 11850 });
+    const r = describeContributions({ ...ledger, invested: { investedEur: 16700, divestedEur: 2500, netInvestedEur: 14200 }, netCashFlow: 11850, cashflowNet: 11850 });
     expect(plain(r)).toBe('Hai investito 14.200 € dal registro, a fronte di 11.850 € messi da parte.');
   });
 
   it('says when the cashflow is negative and when the ledger sold more than it bought', () => {
-    expect(plain(describeContributions({ invested: { investedEur: 1000, divestedEur: 4000, netInvestedEur: -3000 }, netCashFlow: -2300 }))).toBe('Hai disinvestito 3000 € dal registro, mentre dal cashflow sono usciti 2300 € più di quanto è entrato.');
-    expect(plain(describeContributions({ invested: { investedEur: 5000, divestedEur: 0, netInvestedEur: 5000 }, netCashFlow: -900 }))).toBe('Hai investito 5000 € dal registro, mentre dal cashflow sono usciti 900 € più di quanto è entrato.');
+    expect(plain(describeContributions({ ...ledger, invested: { investedEur: 1000, divestedEur: 4000, netInvestedEur: -3000 }, netCashFlow: -2300, cashflowNet: -2300 }))).toBe('Hai disinvestito 3000 € dal registro, mentre dal cashflow sono usciti 2300 € più di quanto è entrato.');
+    expect(plain(describeContributions({ ...ledger, invested: { investedEur: 5000, divestedEur: 0, netInvestedEur: 5000 }, netCashFlow: -900, cashflowNet: -900 }))).toBe('Hai investito 5000 € dal registro, mentre dal cashflow sono usciti 900 € più di quanto è entrato.');
   });
 
   it('without a ledger it reads the cashflow alone', () => {
-    expect(plain(describeContributions({ invested: null, netCashFlow: 11850 }))).toBe('Dal cashflow hai messo da parte 11.850 € nel periodo; il registro operazioni non è attivo.');
-    expect(plain(describeContributions({ invested: null, netCashFlow: -2300 }))).toBe('Dal cashflow sono usciti 2300 € più di quanto è entrato nel periodo; il registro operazioni non è attivo.');
+    expect(plain(describeContributions({ ...ledger, invested: null, netCashFlow: 11850, cashflowNet: 11850 }))).toBe('Dal cashflow hai messo da parte 11.850 € nel periodo; il registro operazioni non è attivo.');
+    expect(plain(describeContributions({ ...ledger, invested: null, netCashFlow: -2300, cashflowNet: -2300 }))).toBe('Dal cashflow sono usciti 2300 € più di quanto è entrato nel periodo; il registro operazioni non è attivo.');
+  });
+
+  it('reads the MEASURED flow, not the ledger, when the flows follow the portfolio base', () => {
+    // Il registro dice 14.200, la serie misurata 12.400: vince quella misurata, perche' e' quella
+    // che il rendimento ha neutralizzato. Stampare il registro sarebbe un numero mai usato.
+    const r = describeContributions({
+      invested: { investedEur: 16700, divestedEur: 2500, netInvestedEur: 14200 },
+      netCashFlow: 12400,
+      flowSource: 'portfolio',
+      cashflowNet: 11850,
+    });
+    expect(plain(r)).toBe('Sono entrati 12.400 € negli strumenti, a fronte di 11.850 € messi da parte.');
+  });
+
+  it('says it the other way round when the portfolio was net sold', () => {
+    const r = describeContributions({ invested: null, netCashFlow: -3000, flowSource: 'portfolio', cashflowNet: -900 });
+    expect(plain(r)).toBe('Sono usciti 3000 € dagli strumenti, mentre dal cashflow sono usciti 900 € più di quanto è entrato.');
   });
 });
 

--- a/__tests__/performanceRolling.test.ts
+++ b/__tests__/performanceRolling.test.ts
@@ -6,7 +6,10 @@
  *      spese (`date <= endDate`) buttava via l'intero ultimo mese di movimenti;
  *   2. il TWR annualizzava su `windowMonths + 1` mesi mentre il CAGR della stessa riga usava
  *      `windowMonths` → Sharpe rolling e CAGR rolling su basi temporali diverse;
- *   3. i cash flow partivano dal mese dello snapshot di partenza, il cui valore li contiene già.
+ *   3. i cash flow partivano dal mese dello snapshot di partenza, il cui valore li contiene già;
+ *   4. le finestre misuravano il capitale della BASE con i flussi del PATRIMONIO — il fix D1
+ *      («i flussi seguono la base») era arrivato ai cinque periodi fissi e non qui, così ogni
+ *      euro risparmiato fuori dal portafoglio veniva sottratto al rendimento del portafoglio.
  *
  * Le serie sono costruite in modo che la risposta giusta sia **zero**: un movimento perso o contato
  * due volte non può nascondersi dietro un arrotondamento.
@@ -23,8 +26,11 @@ vi.mock('@/lib/services/snapshotService', () => ({}));
 vi.mock('@/lib/services/assetAllocationService', () => ({}));
 
 import { calculateRollingPeriods } from '@/lib/services/performanceService';
+import { buildPortfolioCashFlows } from '@/lib/utils/portfolioFlows';
+import { toPerformanceBaseSnapshots } from '@/lib/utils/performanceBase';
 import type { MonthlySnapshot } from '@/types/assets';
 import type { Expense, ExpenseType } from '@/types/expenses';
+import type { CashFlowData } from '@/types/performance';
 
 const USER = 'user-1';
 const RISK_FREE = 2.5;
@@ -60,6 +66,42 @@ function expense(year: number, month: number, type: ExpenseType, amount: number)
 
 function rolling(snapshots: MonthlySnapshot[], expenses: Expense[] = [], windowMonths = WINDOW) {
   return calculateRollingPeriods(USER, snapshots, windowMonths, RISK_FREE, undefined, expenses);
+}
+
+/** Come `rolling`, ma con i flussi per asset: è ciò che il service passa quando la base esclude. */
+function rollingWithFlows(
+  snapshots: MonthlySnapshot[],
+  expenses: Expense[],
+  portfolioFlows: CashFlowData[],
+  windowMonths = WINDOW,
+) {
+  return calculateRollingPeriods(USER, snapshots, windowMonths, RISK_FREE, undefined, expenses, portfolioFlows);
+}
+
+type Position = { assetId: string; quantity: number; price: number };
+
+/** Uno snapshot col dettaglio per strumento: è il `byAsset` a rendere un mese MISURABILE. */
+function positioned(year: number, month: number, positions: Position[]): MonthlySnapshot {
+  return {
+    year,
+    month,
+    totalNetWorth: positions.reduce((sum, p) => sum + p.quantity * p.price, 0),
+    illiquidNetWorth: 0,
+    isDummy: false,
+    byAsset: positions.map((p) => ({
+      assetId: p.assetId,
+      ticker: p.assetId.toUpperCase(),
+      name: p.assetId,
+      quantity: p.quantity,
+      price: p.price,
+      totalValue: p.quantity * p.price,
+    })),
+  } as MonthlySnapshot;
+}
+
+/** Uno snapshot inserito a mano: nessun `byAsset`, quindi nessuna coppia misurabile. */
+function handEntered(year: number, month: number, totalNetWorth: number): MonthlySnapshot {
+  return { year, month, totalNetWorth, illiquidNetWorth: 0, isDummy: false } as MonthlySnapshot;
 }
 
 describe('calculateRollingPeriods — finestra', () => {
@@ -168,5 +210,80 @@ describe('calculateRollingPeriods — annualizzazione', () => {
 
     expect(window.periodStartDate).toEqual(new Date(2023, 1, 1));
     expect(window.cagr).toBeCloseTo((Math.pow(1.01, 12) - 1) * 100, 6);
+  });
+});
+
+describe('calculateRollingPeriods — i flussi seguono la base', () => {
+  const ETF = 'etf';
+  const CASA = 'casa';
+
+  /** La pipeline vera in due righe: gli snapshot proiettati sulla base, e i flussi per asset. */
+  function baseAware(raw: MonthlySnapshot[], excluded: string[]) {
+    const projected = toPerformanceBaseSnapshots(raw, excluded);
+    return { projected, flows: buildPortfolioCashFlows(projected, excluded) };
+  }
+
+  it('non legge come versamento nel portafoglio il risparmio finito in un asset escluso', async () => {
+    // ETF fermo a 100.000 per tredici mesi: il portafoglio non ha reso niente e non ha ricevuto
+    // niente. La casa, fuori base, sale di 10.000 a gennaio — pagati con i 10.000 che il Cashflow
+    // registra come entrata. Il rendimento vero del portafoglio è zero.
+    const raw = Array.from({ length: 13 }, (_, k) => {
+      const date = new Date(2025, k, 1);
+      return positioned(date.getFullYear(), date.getMonth() + 1, [
+        { assetId: ETF, quantity: 100, price: 1000 },
+        { assetId: CASA, quantity: 1, price: k === 12 ? 210000 : 200000 },
+      ]);
+    });
+    const cashflow = [expense(2026, 1, 'income', 10000)];
+    const { projected, flows } = baseAware(raw, [CASA]);
+
+    const [conFlussi] = await rollingWithFlows(projected, cashflow, flows);
+    expect(conFlussi.cagr!).toBeCloseTo(0, 6);
+
+    // La lettura di prima del fix: capitale del portafoglio, flussi del patrimonio. I 10.000 non
+    // sono mai entrati nell'ETF, eppure venivano sottratti dal suo rendimento.
+    const [senzaFlussi] = await rolling(projected, cashflow);
+    expect(senzaFlussi.cagr!).toBeCloseTo((100000 / 110000 - 1) * 100, 6);
+  });
+
+  it('ricade sul Cashflow nei mesi non misurabili, uno per uno', async () => {
+    // Gennaio-marzo 2025 sono inseriti a mano: nessun `byAsset`, nessuna coppia misurabile. Il
+    // versamento di 20.000 di marzo esiste solo nel Cashflow e deve sopravvivere. Da aprile il
+    // dettaglio c'è, e i mesi misurati valgono zero.
+    const raw = [
+      handEntered(2025, 1, 300000),
+      handEntered(2025, 2, 300000),
+      handEntered(2025, 3, 320000),
+      ...Array.from({ length: 10 }, (_, k) => {
+        const date = new Date(2025, 3 + k, 1);
+        return positioned(date.getFullYear(), date.getMonth() + 1, [
+          { assetId: ETF, quantity: 120, price: 1000 },
+          { assetId: CASA, quantity: 1, price: 200000 },
+        ]);
+      }),
+    ];
+    const cashflow = [expense(2025, 3, 'income', 20000)];
+    const { projected, flows } = baseAware(raw, [CASA]);
+
+    // Il backfill E₀ = 200.000 riporta i mesi senza dettaglio sulla stessa base degli altri.
+    expect(projected.slice(0, 3).map((s) => s.totalNetWorth)).toEqual([100000, 100000, 120000]);
+    // Misurabili solo da maggio: serve il `byAsset` di ENTRAMBI i mesi della coppia.
+    expect(flows.map((f) => f.date.getMonth() + 1)).toEqual([5, 6, 7, 8, 9, 10, 11, 12, 1]);
+    expect(flows.every((f) => f.netCashFlow === 0)).toBe(true);
+
+    const [window] = await rollingWithFlows(projected, cashflow, flows);
+
+    // 120.000 partendo da 100.000 con 20.000 versati fa zero. Se il fallback fosse per PERIODO
+    // invece che per mese il versamento sparirebbe, e la finestra leggerebbe +20%.
+    expect(window.cagr!).toBeCloseTo(0, 6);
+  });
+
+  it('un CAGR non misurabile è `null`, non uno zero', async () => {
+    // Il portafoglio nasce a gennaio: la valutazione di partenza è zero, e da zero non esiste un
+    // tasso di crescita. Scriverlo 0% direbbe «quell'anno non ha reso», che è un'altra frase —
+    // ed è quello che `cagr || 0` faceva.
+    const [window] = await rolling(series(2025, 1, [0, ...Array(12).fill(100000)]));
+
+    expect(window.cagr).toBeNull();
   });
 });

--- a/__tests__/performanceService.test.ts
+++ b/__tests__/performanceService.test.ts
@@ -1100,8 +1100,11 @@ describe('buildCacheKey', () => {
     // v5 -> v6 il 2026-08-30: i flussi seguono la base (fix D1, portfolioFlows.ts). Ogni numero
     // in cache era stato calcolato con i flussi del Cashflow anche dove la base escludeva la
     // liquidita', ed e' da buttare.
-    expect(buildCacheKey(baseline).startsWith('v6-')).toBe(true)
-    expect(buildCacheKey({ ...baseline, snapshots: [] }).startsWith('v6-')).toBe(true)
+    // v6 -> v7 il 2026-08-31: la stessa regola arriva alle finestre rolling, che erano rimaste
+    // fuori dal fix D1 (capitale del portafoglio, flussi del patrimonio), e un CAGR non
+    // misurabile smette di essere scritto come 0.
+    expect(buildCacheKey(baseline).startsWith('v7-')).toBe(true)
+    expect(buildCacheKey({ ...baseline, snapshots: [] }).startsWith('v7-')).toBe(true)
   })
 
   it('ignores the order snapshots arrive in', () => {

--- a/__tests__/performanceService.test.ts
+++ b/__tests__/performanceService.test.ts
@@ -1097,8 +1097,11 @@ describe('buildCacheKey', () => {
     // l'utente continua a leggere numeri pre-fix per 6 ore. Il test è qui perché il bump è manuale
     // e va ricordato — se questa asserzione fallisce dopo un cambio di matematica, è corretto
     // aggiornarla; se fallisce senza, qualcuno ha rotto il prefisso.
-    expect(buildCacheKey(baseline).startsWith('v5-')).toBe(true)
-    expect(buildCacheKey({ ...baseline, snapshots: [] }).startsWith('v5-')).toBe(true)
+    // v5 -> v6 il 2026-08-30: i flussi seguono la base (fix D1, portfolioFlows.ts). Ogni numero
+    // in cache era stato calcolato con i flussi del Cashflow anche dove la base escludeva la
+    // liquidita', ed e' da buttare.
+    expect(buildCacheKey(baseline).startsWith('v6-')).toBe(true)
+    expect(buildCacheKey({ ...baseline, snapshots: [] }).startsWith('v6-')).toBe(true)
   })
 
   it('ignores the order snapshots arrive in', () => {
@@ -1216,5 +1219,40 @@ describe('preparePerformanceChartData', () => {
     expect(chart.length).toBe(2)
     expect(chart[0].date).toBe('02/2025')
     expect(chart[0].initialCapital).toBe(200000)
+  })
+})
+
+// Importando la storia vera (2024-10 in poi) aprile 2025 e' un mese interamente liquidato, e con
+// qualche saldo netto negativo la base di partenza puo' scendere sotto zero. Un denominatore
+// negativo non fallisce: ribalta il segno, e la catena del TWR si azzera in silenzio.
+describe('una base di partenza non positiva non produce un rendimento', () => {
+  function nw(year: number, month: number, totalNetWorth: number) {
+    return {
+      userId: 'user-1', year, month, totalNetWorth,
+      liquidNetWorth: totalNetWorth, illiquidNetWorth: 0,
+      byAssetClass: {}, byAsset: [], assetAllocation: {},
+      createdAt: new Date(year, month - 1, 28),
+    } as never
+  }
+
+  it('calculateROI returns null on a zero or negative starting capital', () => {
+    expect(calculateROI(-800, 31_000, 31_000)).toBeNull()
+    expect(calculateROI(0, 31_000, 31_000)).toBeNull()
+  })
+
+  it('the TWR skips the month instead of collapsing the chain', () => {
+    // gen 1000 -> feb 1100 (+10%), poi una liquidazione porta la base a -800 e il mese dopo risale.
+    // Senza la guardia il mese ripartito da -800 varrebbe -100% e azzererebbe tutto.
+    const snapshots = [nw(2026, 1, 1000), nw(2026, 2, 1100), nw(2026, 3, -800), nw(2026, 4, 900)]
+    const flows = [
+      { date: new Date(2026, 2, 1), income: 0, expenses: 0, dividendIncome: 0, netCashFlow: -1900 },
+      { date: new Date(2026, 3, 1), income: 0, expenses: 0, dividendIncome: 0, netCashFlow: 1700 },
+    ]
+
+    const twr = calculateTimeWeightedReturn(snapshots, flows, 3)
+
+    expect(twr).not.toBeNull()
+    expect(Number.isFinite(twr!)).toBe(true)
+    expect(twr!).toBeGreaterThan(0)
   })
 })

--- a/__tests__/portfolioFlows.test.ts
+++ b/__tests__/portfolioFlows.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from 'vitest';
+import { buildPortfolioCashFlows, computeMonthlyPortfolioFlow, indexLedger } from '@/lib/utils/portfolioFlows';
+import type { MonthlySnapshot } from '@/types/assets';
+import type { AssetTransaction } from '@/types/assetTransactions';
+
+function trade(
+  assetId: string,
+  type: AssetTransaction['type'],
+  date: Date,
+  quantity: number,
+  priceEur: number,
+  fees?: number,
+): AssetTransaction {
+  return { id: `${assetId}-${date.toISOString()}-${quantity}`, userId: 'user-1', assetId, type, date,
+    quantity, pricePerUnit: priceEur, priceEur, fees, createdAt: date, updatedAt: date };
+}
+
+type Position = { assetId: string; quantity: number; price: number };
+
+function makeSnapshot(year: number, month: number, positions: Position[]): MonthlySnapshot {
+  return {
+    userId: 'user-1',
+    year,
+    month,
+    totalNetWorth: positions.reduce((sum, p) => sum + p.quantity * p.price, 0),
+    liquidNetWorth: 0,
+    illiquidNetWorth: 0,
+    byAssetClass: {},
+    byAsset: positions.map((p) => ({
+      assetId: p.assetId,
+      ticker: p.assetId.toUpperCase(),
+      name: p.assetId,
+      quantity: p.quantity,
+      price: p.price,
+      totalValue: p.quantity * p.price,
+    })),
+    assetAllocation: {},
+    createdAt: new Date(year, month - 1, 28),
+  } as MonthlySnapshot;
+}
+
+describe('computeMonthlyPortfolioFlow', () => {
+  it('reads a price move as no flow at all', () => {
+    const before = makeSnapshot(2026, 1, [{ assetId: 'etf', quantity: 100, price: 10 }]);
+    const after = makeSnapshot(2026, 2, [{ assetId: 'etf', quantity: 100, price: 12 }]);
+
+    expect(computeMonthlyPortfolioFlow(before, after, new Set())).toBe(0);
+  });
+
+  it('values a purchase at the month price', () => {
+    const before = makeSnapshot(2026, 1, [{ assetId: 'etf', quantity: 100, price: 10 }]);
+    const after = makeSnapshot(2026, 2, [{ assetId: 'etf', quantity: 150, price: 12 }]);
+
+    expect(computeMonthlyPortfolioFlow(before, after, new Set())).toBe(600);
+  });
+
+  it('reads a sale as a negative flow', () => {
+    const before = makeSnapshot(2026, 1, [{ assetId: 'etf', quantity: 100, price: 10 }]);
+    const after = makeSnapshot(2026, 2, [{ assetId: 'etf', quantity: 40, price: 10 }]);
+
+    expect(computeMonthlyPortfolioFlow(before, after, new Set())).toBe(-600);
+  });
+
+  it('values a position closed during the month at its last known price', () => {
+    const before = makeSnapshot(2026, 1, [{ assetId: 'etf', quantity: 100, price: 10 }]);
+    const after = makeSnapshot(2026, 2, []);
+
+    expect(computeMonthlyPortfolioFlow(before, after, new Set())).toBe(-1000);
+  });
+
+  it('ignores assets outside the base', () => {
+    // La liquidita' cala mentre lo strumento cresce: e' il denaro che attraversa il confine,
+    // e va contato UNA volta sola, dal lato che sta dentro la base.
+    const before = makeSnapshot(2026, 1, [
+      { assetId: 'etf', quantity: 100, price: 10 },
+      { assetId: 'conto', quantity: 5000, price: 1 },
+    ]);
+    const after = makeSnapshot(2026, 2, [
+      { assetId: 'etf', quantity: 200, price: 10 },
+      { assetId: 'conto', quantity: 4000, price: 1 },
+    ]);
+
+    expect(computeMonthlyPortfolioFlow(before, after, new Set(['conto']))).toBe(1000);
+  });
+
+  it('nets purchases against sales inside the same month', () => {
+    const before = makeSnapshot(2026, 1, [
+      { assetId: 'a', quantity: 100, price: 10 },
+      { assetId: 'b', quantity: 50, price: 20 },
+    ]);
+    const after = makeSnapshot(2026, 2, [
+      { assetId: 'a', quantity: 130, price: 10 },
+      { assetId: 'b', quantity: 40, price: 20 },
+    ]);
+
+    expect(computeMonthlyPortfolioFlow(before, after, new Set())).toBe(100);
+  });
+});
+
+describe('buildPortfolioCashFlows', () => {
+  it('emits one flow per month MISURABILE, dated to the first of that month', () => {
+    const flows = buildPortfolioCashFlows(
+      [
+        makeSnapshot(2026, 1, [{ assetId: 'etf', quantity: 100, price: 10 }]),
+        makeSnapshot(2026, 2, [{ assetId: 'etf', quantity: 150, price: 10 }]),
+        makeSnapshot(2026, 3, [{ assetId: 'etf', quantity: 150, price: 11 }]),
+        makeSnapshot(2026, 4, [{ assetId: 'etf', quantity: 200, price: 11 }]),
+      ],
+      []
+    );
+
+    expect(flows).toHaveLength(3);
+    expect(flows.map((f) => [f.date, f.netCashFlow])).toEqual([
+      [new Date(2026, 1, 1), 500],
+      // Marzo e' MISURATO e vale zero: solo il prezzo si e' mosso. Una voce a zero e un mese
+      // assente sono fatti diversi — chi consuma i flussi ricade sul Cashflow solo per il secondo.
+      [new Date(2026, 2, 1), 0],
+      [new Date(2026, 3, 1), 550],
+    ]);
+  });
+
+  it('non emette nulla per una coppia in cui MANCA il breakdown, da una parte o dall\'altra', () => {
+    // E' il caso di chi ha uno storico inserito a mano: senza questa distinzione i suoi flussi
+    // sarebbero tutti nulli e ogni versamento verrebbe letto come rendimento.
+    const senzaBreakdown = makeSnapshot(2026, 2, []);
+    const flows = buildPortfolioCashFlows(
+      [
+        makeSnapshot(2026, 1, [{ assetId: 'etf', quantity: 100, price: 10 }]),
+        senzaBreakdown,
+        makeSnapshot(2026, 3, [{ assetId: 'etf', quantity: 100, price: 10 }]),
+        makeSnapshot(2026, 4, [{ assetId: 'etf', quantity: 120, price: 10 }]),
+      ],
+      []
+    );
+
+    // (gen,feb) e (feb,mar) non sono misurabili; (mar,apr) si'.
+    expect(flows.map((f) => f.date)).toEqual([new Date(2026, 3, 1)]);
+    expect(flows[0].netCashFlow).toBe(200);
+  });
+
+  it('un asset opaco al flusso non contribuisce con le Δquantità', () => {
+    // Un fondo pensione tiene il valore in `quantity` con prezzo 1: la sua quantita' cresce sia per
+    // i versamenti sia per il mercato, e leggerla come flusso cancellerebbe il suo rendimento.
+    const prima = makeSnapshot(2026, 1, [
+      { assetId: 'etf', quantity: 100, price: 10 },
+      { assetId: 'fondo', quantity: 5000, price: 1 },
+    ]);
+    const dopo = makeSnapshot(2026, 2, [
+      { assetId: 'etf', quantity: 120, price: 10 },
+      { assetId: 'fondo', quantity: 5400, price: 1 },
+    ]);
+
+    expect(computeMonthlyPortfolioFlow(prima, dopo, new Set(), undefined, new Set(['fondo']))).toBe(200);
+    // Senza marcarlo opaco i 400 del fondo sparirebbero dal rendimento.
+    expect(computeMonthlyPortfolioFlow(prima, dopo, new Set())).toBe(600);
+  });
+
+  it('un conto corrente NON è opaco: il suo saldo che cambia è denaro che si muove', () => {
+    // Ed e' cio' che fa tornare i conti con la liquidita' DENTRO la base: l'ETF fa +200, il conto
+    // -200, e il flusso netto e' zero perche' non e' entrato niente dall'esterno.
+    const prima = makeSnapshot(2026, 1, [
+      { assetId: 'etf', quantity: 100, price: 10 },
+      { assetId: 'conto', quantity: 5000, price: 1 },
+    ]);
+    const dopo = makeSnapshot(2026, 2, [
+      { assetId: 'etf', quantity: 120, price: 10 },
+      { assetId: 'conto', quantity: 4800, price: 1 },
+    ]);
+
+    expect(computeMonthlyPortfolioFlow(prima, dopo, new Set())).toBe(0);
+  });
+
+  it('leaves income, expenses and dividends at zero — a purchase is none of those', () => {
+    const flows = buildPortfolioCashFlows(
+      [
+        makeSnapshot(2026, 1, [{ assetId: 'etf', quantity: 100, price: 10 }]),
+        makeSnapshot(2026, 2, [{ assetId: 'etf', quantity: 150, price: 10 }]),
+      ],
+      []
+    );
+
+    expect(flows[0]).toMatchObject({ income: 0, expenses: 0, dividendIncome: 0 });
+  });
+
+  it('sorts an unordered input before pairing months', () => {
+    const january = makeSnapshot(2026, 1, [{ assetId: 'etf', quantity: 100, price: 10 }]);
+    const february = makeSnapshot(2026, 2, [{ assetId: 'etf', quantity: 150, price: 10 }]);
+
+    expect(buildPortfolioCashFlows([february, january], [])[0].netCashFlow).toBe(500);
+  });
+
+  it('skips months without a breakdown instead of inventing a flow', () => {
+    const withoutBreakdown = makeSnapshot(2026, 2, []);
+    withoutBreakdown.byAsset = [];
+    const flows = buildPortfolioCashFlows(
+      [
+        makeSnapshot(2026, 1, [{ assetId: 'etf', quantity: 100, price: 10 }]),
+        withoutBreakdown,
+        makeSnapshot(2026, 3, [{ assetId: 'etf', quantity: 100, price: 10 }]),
+      ],
+      []
+    );
+
+    expect(flows).toHaveLength(0);
+  });
+
+  it('crosses a year boundary in the right order', () => {
+    const flows = buildPortfolioCashFlows(
+      [
+        makeSnapshot(2025, 12, [{ assetId: 'etf', quantity: 100, price: 10 }]),
+        makeSnapshot(2026, 1, [{ assetId: 'etf', quantity: 120, price: 10 }]),
+      ],
+      []
+    );
+
+    expect(flows).toHaveLength(1);
+    expect(flows[0].netCashFlow).toBe(200);
+  });
+});
+
+// Il registro e' la fonte PREFERITA, per asset: e' datato all'operazione, mentre uno snapshot e'
+// datato alla rilevazione. Ma da solo non regge la storia, perche' conosce solo cio' che e' stato
+// registrato — e le due fonti insieme, per asset, coprono entrambi i buchi.
+describe('registro operazioni e Δquantità, per asset', () => {
+  const gennaio = makeSnapshot(2026, 1, [{ assetId: 'etf', quantity: 100, price: 10 }]);
+  const febbraio = makeSnapshot(2026, 2, [{ assetId: 'etf', quantity: 150, price: 12 }]);
+
+  it("preferisce il registro dove l'asset è coperto, col prezzo dell'operazione", () => {
+    // Δquantità direbbe 50 x 12 = 600 (prezzo di fine mese); il registro dice 50 x 11 = 550.
+    const flow = computeMonthlyPortfolioFlow(gennaio, febbraio, new Set(),
+      indexLedger([trade('etf', 'buy', new Date(2026, 1, 14), 50, 11)]));
+
+    expect(flow).toBe(550);
+  });
+
+  it('somma le commissioni al flusso di un acquisto e le sottrae dal ricavo di una vendita', () => {
+    const comprato = indexLedger([trade('etf', 'buy', new Date(2026, 1, 14), 50, 11, 9)]);
+    expect(computeMonthlyPortfolioFlow(gennaio, febbraio, new Set(), comprato)).toBe(559);
+
+    const marzo = makeSnapshot(2026, 3, [{ assetId: 'etf', quantity: 100, price: 12 }]);
+    const venduto = indexLedger([trade('etf', 'sell', new Date(2026, 2, 10), 50, 11, 9)]);
+    expect(computeMonthlyPortfolioFlow(febbraio, marzo, new Set(), venduto)).toBe(-541);
+  });
+
+  it("per un asset coperto, nessuna operazione nel mese significa flusso zero — non un buco da riempire", () => {
+    // L'asset e' coperto da gennaio; a febbraio il registro tace, quindi il flusso e' 0 e tutta la
+    // variazione e' rendimento. Le Δquantità NON intervengono a coprire il silenzio.
+    const ledger = indexLedger([trade('etf', 'buy', new Date(2026, 0, 5), 100, 10)]);
+
+    expect(computeMonthlyPortfolioFlow(gennaio, febbraio, new Set(), ledger)).toBe(0);
+  });
+
+  it('ricade sulle Δquantità per un asset che nel registro non compare mai', () => {
+    // Il caso reale: strumenti tenuti su un altro intermediario, venduti senza che nessuna
+    // operazione sia stata registrata.
+    const ledger = indexLedger([trade('altro', 'buy', new Date(2026, 1, 3), 1, 1)]);
+
+    expect(computeMonthlyPortfolioFlow(gennaio, febbraio, new Set(['altro']), ledger)).toBe(600);
+  });
+
+  it("ricade sulle Δquantità per i mesi PRECEDENTI alla prima operazione dell'asset", () => {
+    // Un asset comprato altrove e poi tracciato: prima della prima operazione il registro non sa
+    // nulla, e negare le Δquantità li' significherebbe leggere un acquisto come rendimento.
+    const ledger = indexLedger([trade('etf', 'buy', new Date(2026, 5, 1), 10, 12)]);
+
+    expect(computeMonthlyPortfolioFlow(gennaio, febbraio, new Set(), ledger)).toBe(600);
+  });
+
+  it('mescola le due fonti nello stesso mese, una per asset', () => {
+    // E' aprile 2025 in miniatura: il nuovo strumento entra dal registro, il vecchio esce dalle
+    // quantità perché la sua vendita non è registrata da nessuna parte.
+    const prima = makeSnapshot(2026, 1, [{ assetId: 'vecchio', quantity: 200, price: 100 }]);
+    const dopo = makeSnapshot(2026, 2, [{ assetId: 'nuovo', quantity: 300, price: 100 }]);
+    const ledger = indexLedger([trade('nuovo', 'buy', new Date(2026, 1, 28), 300, 100)]);
+
+    expect(computeMonthlyPortfolioFlow(prima, dopo, new Set(), ledger)).toBe(10_000);
+  });
+
+  it('un adjustment non muove denaro, ma rende comunque coperto l\'asset', () => {
+    const ledger = indexLedger([trade('etf', 'adjustment', new Date(2026, 0, 9), 100, 10)]);
+
+    expect(ledger.coveredFrom.get('etf')).toBe('2026-01');
+    expect(computeMonthlyPortfolioFlow(gennaio, febbraio, new Set(), ledger)).toBe(0);
+  });
+
+  it('senza registro si comporta esattamente come prima', () => {
+    expect(buildPortfolioCashFlows([gennaio, febbraio], [])[0].netCashFlow).toBe(600);
+    expect(buildPortfolioCashFlows([gennaio, febbraio], [], [])[0].netCashFlow).toBe(600);
+  });
+});

--- a/app/dashboard/performance/page.tsx
+++ b/app/dashboard/performance/page.tsx
@@ -42,6 +42,8 @@ import {
   prepareMonthlyReturnsHeatmap,
   prepareUnderwaterDrawdownData,
 } from '@/lib/services/performanceService';
+import { buildPortfolioCashFlows } from '@/lib/utils/portfolioFlows';
+import { getAssetTransactions } from '@/lib/services/assetTransactionService';
 import { getUserSnapshots } from '@/lib/services/snapshotService';
 import { getAllAssets } from '@/lib/services/assetService';
 import { getSettings } from '@/lib/services/assetAllocationService';
@@ -52,7 +54,7 @@ import {
   toPerformanceBaseSnapshots,
   type PerformanceBaseOptions,
 } from '@/lib/utils/performanceBase';
-import type { PerformanceData, PerformanceMetrics, TimePeriod } from '@/types/performance';
+import type { CashFlowData, PerformanceData, PerformanceMetrics, TimePeriod } from '@/types/performance';
 import type { MonthlySnapshot } from '@/types/assets';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
@@ -243,6 +245,7 @@ export default function PerformancePage() {
   const [showCustomDateDialog, setShowCustomDateDialog] = useState(false);
   const [showAIAnalysisDialog, setShowAIAnalysisDialog] = useState(false);
   const [cachedSnapshots, setCachedSnapshots] = useState<MonthlySnapshot[]>([]);
+  const [cachedPortfolioFlows, setCachedPortfolioFlows] = useState<CashFlowData[] | undefined>(undefined);
   // Kept in state only to name the base under the verdict — the numbers themselves already carry it via
   // cachedSnapshots. Defaults match resolvePerformanceBaseOptions so the caption is right on first paint.
   const [baseOptions, setBaseOptions] = useState<PerformanceBaseOptions>({
@@ -330,9 +333,25 @@ export default function PerformancePage() {
       // heatmap and custom-range helpers read cachedSnapshots directly, so they need the exact same
       // exclusions — and the same settings — or a custom period would disagree with the pre-computed ones.
       const options = resolvePerformanceBaseOptions(baseSettings);
-      const snapshots = toPerformanceBaseSnapshots(rawSnapshots, resolvePerformanceExclusions(assetsForBase, options));
+      const exclusions = resolvePerformanceExclusions(assetsForBase, options);
+      const snapshots = toPerformanceBaseSnapshots(rawSnapshots, exclusions);
       setCachedSnapshots(snapshots);
       setBaseOptions(options);
+      // Stessa regola e stessa condizione del service (getAllPerformanceData): i flussi seguono la
+      // base. Senza questa riga un periodo CUSTOM userebbe i flussi del Cashflow mentre YTD/1Y/…
+      // usano quelli del portafoglio, e i due non tornerebbero.
+      // Stessa condizione, stesse opzioni e stessi asset opachi del service: un periodo CUSTOM che
+      // usasse una fonte diversa da YTD/1Y/… non tornerebbe con i numeri precalcolati.
+      setCachedPortfolioFlows(
+        exclusions.length === 0
+          ? undefined
+          : buildPortfolioCashFlows(
+              snapshots,
+              exclusions,
+              await getAssetTransactions(ownerId).catch(() => []), // già segnalato dal service
+              assetsForBase.filter((a) => a.type === 'pensionFund').map((a) => a.id),
+            ),
+      );
 
       const data = await getAllPerformanceData(ownerId, hasLoadedOnceRef.current);
 
@@ -375,6 +394,7 @@ export default function PerformancePage() {
         endDate,
         undefined,
         performanceData.ytd.dividendCategoryId,
+        cachedPortfolioFlows,
       );
       Object.assign(customMetrics, await fetchYieldMetrics(ownerId, customMetrics));
       setPerformanceData({ ...performanceData, custom: customMetrics });
@@ -709,9 +729,17 @@ export default function PerformancePage() {
         {/* Below desktop the benchmark reads before the contributions: «rispetto a cosa?» is the page's question. */}
         <div className={cn(TILE_CELL_CLASS, 'order-5 desktop:order-none desktop:col-span-3')}>
           <ContributiTile
-            reading={describeContributions({ invested: investedCapital, netCashFlow: metrics.netCashFlow })}
+            reading={describeContributions({
+              invested: investedCapital,
+              netCashFlow: metrics.netCashFlow,
+              flowSource: metrics.flowSource,
+              cashflowNet: metrics.totalIncome - metrics.totalExpenses,
+            })}
             invested={investedCapital}
             netCashFlow={metrics.netCashFlow}
+            totalContributions={metrics.totalContributions}
+            totalWithdrawals={metrics.totalWithdrawals}
+            flowSource={metrics.flowSource}
             totalIncome={metrics.totalIncome}
             totalExpenses={metrics.totalExpenses}
             totalDividendIncome={metrics.totalDividendIncome}

--- a/app/dashboard/performance/page.tsx
+++ b/app/dashboard/performance/page.tsx
@@ -522,7 +522,10 @@ export default function PerformancePage() {
     });
     // A 3-month moving average smooths the month-to-month noise without lagging behind the trend.
     return rows.map((entry, index) => {
-      const window = rows.slice(Math.max(0, index - 2), index + 1).map((r) => r.cagr).filter((v) => Number.isFinite(v));
+      const window = rows
+        .slice(Math.max(0, index - 2), index + 1)
+        .map((r) => r.cagr)
+        .filter((v): v is number => v !== null && Number.isFinite(v));
       return { ...entry, cagrMA: window.length > 0 ? window.reduce((s, v) => s + v, 0) / window.length : null };
     });
   }, [performanceData, metrics]);

--- a/components/performance/PerformanceDettaglio.tsx
+++ b/components/performance/PerformanceDettaglio.tsx
@@ -292,7 +292,7 @@ export function PerformanceDettaglio({ metrics, periodAside, drawdown, rollingCa
             <RollingTile
               eyebrow="CAGR rolling 12 mesi"
               aside="nel periodo"
-              reading={describeRolling(rollingCagr.map((p) => p.cagr), (v) => signedPercent(v, 1), 'Il CAGR')}
+              reading={describeRolling(rollingCagr.map((p) => p.cagr).filter((v): v is number => v !== null), (v) => signedPercent(v, 1), 'Il CAGR')}
               data={rollingCagr}
               primaryKey="cagr"
               averageKey="cagrMA"

--- a/components/performance/tiles/ContributiTile.tsx
+++ b/components/performance/tiles/ContributiTile.tsx
@@ -12,6 +12,9 @@ interface ContributiTileProps {
   /** Buys minus sells from the trade ledger in the period; null while the ledger is not migrated. */
   invested: { investedEur: number; divestedEur: number; netInvestedEur: number } | null;
   netCashFlow: number;
+  totalContributions: number;
+  totalWithdrawals: number;
+  flowSource: 'portfolio' | 'cashflow' | 'mixed';
   totalIncome: number;
   totalExpenses: number;
   totalDividendIncome: number;
@@ -48,25 +51,63 @@ function Help({ label, children }: { label: string; children: React.ReactNode })
  * purpose: the ledger's buys minus sells and the cashflow's income minus spending. They are not
  * two versions of one number, and each carries its own definition behind the «?».
  */
-export function ContributiTile({ reading, invested, netCashFlow, totalIncome, totalExpenses, totalDividendIncome, className }: ContributiTileProps) {
+export function ContributiTile({
+  reading,
+  invested,
+  netCashFlow,
+  totalContributions,
+  totalWithdrawals,
+  flowSource,
+  totalIncome,
+  totalExpenses,
+  totalDividendIncome,
+  className,
+}: ContributiTileProps) {
+  // Quando i flussi seguono la base (portfolioFlows.ts) il capitale investito NON viene piu' dal
+  // registro operazioni ma dalla serie misurata — ed e' quello che il rendimento ha effettivamente
+  // neutralizzato. Mostrare il registro mentre si misura con un'altra serie significherebbe
+  // stampare un numero che nessuna formula ha usato. `mixed` conta come misurato: la parte dal
+  // Cashflow e' un ripiego sui mesi senza breakdown, e la nota in fondo lo dice.
+  const measuredFlow = flowSource === 'portfolio' || flowSource === 'mixed';
+  const showInvested = measuredFlow || invested !== null;
+  const cashflowNet = totalIncome - totalExpenses;
+
   return (
     <Tile eyebrow="Contributi" aside="nel periodo" reading={reading} className={className}>
-      <div className={cn('mt-4 grid gap-4', invested ? 'grid-cols-1 tablet:grid-cols-2' : 'grid-cols-1')}>
-        {invested && (
+      <div className={cn('mt-4 grid gap-4', showInvested ? 'grid-cols-1 tablet:grid-cols-2' : 'grid-cols-1')}>
+        {measuredFlow ? (
           <div className="min-w-0">
             <p className={cn(TILE_SUB_EYEBROW_CLASS, 'flex items-center')}>
               Capitale investito
               <Help label="Capitale investito">
-                Acquisti meno vendite registrati nel registro operazioni nel periodo, commissioni incluse. Misura quanto
-                denaro è andato sugli strumenti, non quanto ne hai messo da parte.
+                Quanto denaro è entrato negli strumenti nel periodo, letto dalle variazioni di quantità mese per mese:
+                una posizione che cresce è capitale entrato, una che cala è capitale uscito. È la stessa serie che il
+                rendimento toglie dal calcolo, così un acquisto non viene mai letto come guadagno.
               </Help>
             </p>
-            <p className={cn(KPI_VALUE_CLASS, 'mt-1.5 text-foreground')}>{signedEuro(invested.netInvestedEur)}</p>
+            <p className={cn(KPI_VALUE_CLASS, 'mt-1.5 text-foreground')}>{signedEuro(netCashFlow)}</p>
             <p className="mt-1.5 text-[11px] text-muted-foreground">
-              acquisti <span className="font-mono tabular-nums">{cachedFormatCurrencyEUR(invested.investedEur, true)}</span> · vendite{' '}
-              <span className="font-mono tabular-nums">{cachedFormatCurrencyEUR(invested.divestedEur, true)}</span>
+              acquisti <span className="font-mono tabular-nums">{cachedFormatCurrencyEUR(totalContributions, true)}</span> · vendite{' '}
+              <span className="font-mono tabular-nums">{cachedFormatCurrencyEUR(totalWithdrawals, true)}</span>
             </p>
           </div>
+        ) : (
+          invested && (
+            <div className="min-w-0">
+              <p className={cn(TILE_SUB_EYEBROW_CLASS, 'flex items-center')}>
+                Capitale investito
+                <Help label="Capitale investito">
+                  Acquisti meno vendite registrati nel registro operazioni nel periodo, commissioni incluse. Misura quanto
+                  denaro è andato sugli strumenti, non quanto ne hai messo da parte.
+                </Help>
+              </p>
+              <p className={cn(KPI_VALUE_CLASS, 'mt-1.5 text-foreground')}>{signedEuro(invested.netInvestedEur)}</p>
+              <p className="mt-1.5 text-[11px] text-muted-foreground">
+                acquisti <span className="font-mono tabular-nums">{cachedFormatCurrencyEUR(invested.investedEur, true)}</span> · vendite{' '}
+                <span className="font-mono tabular-nums">{cachedFormatCurrencyEUR(invested.divestedEur, true)}</span>
+              </p>
+            </div>
+          )
         )}
         <div className="min-w-0">
           <p className={cn(TILE_SUB_EYEBROW_CLASS, 'flex items-center')}>
@@ -77,7 +118,7 @@ export function ContributiTile({ reading, invested, netCashFlow, totalIncome, to
               non un contributo. Positivo = stai risparmiando.
             </Help>
           </p>
-          <p className={cn(KPI_VALUE_CLASS, 'mt-1.5 text-foreground')}>{signedEuro(netCashFlow)}</p>
+          <p className={cn(KPI_VALUE_CLASS, 'mt-1.5 text-foreground')}>{signedEuro(cashflowNet)}</p>
           <p className="mt-1.5 text-[11px] text-muted-foreground">
             entrate <span className="font-mono tabular-nums">{cachedFormatCurrencyEUR(totalIncome, true)}</span> · uscite{' '}
             <span className="font-mono tabular-nums">{cachedFormatCurrencyEUR(totalExpenses, true)}</span>
@@ -85,9 +126,13 @@ export function ContributiTile({ reading, invested, netCashFlow, totalIncome, to
         </div>
       </div>
       <p className="mt-auto border-t border-border pt-3.5 text-[11px] leading-[1.45] text-muted-foreground">
-        {invested
-          ? 'Due misure diverse di proposito: il registro conta gli acquisti meno le vendite, il cashflow il risparmio. I dividendi non sono contributi.'
-          : 'Il capitale investito arriva dal registro operazioni, non ancora attivo su questo account; i contributi vengono dal cashflow.'}
+        {flowSource === 'mixed'
+          ? 'Due misure diverse di proposito: il capitale investito è il denaro entrato negli strumenti, il cashflow è quanto ne hai messo da parte. Per i mesi senza dettaglio per strumento il primo ricade sul secondo. I dividendi non sono contributi.'
+          : measuredFlow
+          ? 'Due misure diverse di proposito: il capitale investito è il denaro entrato negli strumenti, il cashflow è quanto ne hai messo da parte. I dividendi non sono contributi.'
+          : invested
+            ? 'Due misure diverse di proposito: il registro conta gli acquisti meno le vendite, il cashflow il risparmio. I dividendi non sono contributi.'
+            : 'Il capitale investito arriva dal registro operazioni, non ancora attivo su questo account; i contributi vengono dal cashflow.'}
       </p>
     </Tile>
   );

--- a/lib/services/performanceService.ts
+++ b/lib/services/performanceService.ts
@@ -47,9 +47,11 @@ const PERFORMANCE_CACHE_COLLECTION = 'performance-cache';
  * WARNING (checklist comment): bump on ANY change that alters what the pipeline computes from
  * unchanged inputs, and only then. History: v2 = baseline data-driven + first-month cash flows +
  * TWR annualization; v3 = rolling windows; v4 = IRR signs and timeline; v5 = volatility without
- * the ±50% filter, and its 3-observation floor.
+ * the ±50% filter, and its 3-observation floor; v6 = i flussi seguono la base nei periodi fissi;
+ * v7 = i flussi seguono la base anche nelle finestre rolling, e un CAGR non misurabile smette di
+ * essere letto come 0.
  */
-const CACHE_MATH_VERSION = 'v6';
+const CACHE_MATH_VERSION = 'v7';
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -970,6 +972,58 @@ export function getCashFlowsFromExpenses(
 }
 
 /**
+ * I FLUSSI SEGUONO LA BASE (fix D1, 2026-08-30), **mese per mese**.
+ *
+ * Una base sono due meta': QUALE capitale si misura (`toPerformanceBaseSnapshots`) e QUALI flussi
+ * lo attraversano. Applicarne una sola produce una coppia incoerente — capitale del portafoglio
+ * con i versamenti dell'intero patrimonio — che non risponde a nessuna delle due domande. Questa
+ * funzione e' l'unica risposta alla seconda meta', condivisa da ogni finestra di misura: i cinque
+ * periodi fissi e le finestre rolling.
+ *
+ * `portfolioFlows` porta una voce per ogni mese MISURABILE (serve il `byAsset` di entrambi i mesi
+ * della coppia), zeri compresi. Un mese assente non e' un mese a flusso nullo: e' un mese che non
+ * si puo' misurare, e li' si ricade sul Cashflow. Senza questo fallback uno storico fatto di
+ * snapshot inseriti a mano — nessun breakdown — finirebbe con flussi tutti nulli e ogni
+ * versamento verrebbe letto come rendimento: una regressione grave e silenziosa rispetto al
+ * comportamento precedente.
+ *
+ * `portfolioFlows` assente significa «la base E' il patrimonio» (nessuna esclusione): il Cashflow
+ * e' allora la fonte GIUSTA, non un ripiego, e la funzione degrada a identita'.
+ *
+ * @param expenseFlows - I flussi del Cashflow della finestra, gia' filtrati per data
+ * @param portfolioFlows - I flussi per asset su tutta la storia, o `undefined` senza esclusioni
+ * @param startDate - Inizio della finestra misurata (incluso)
+ * @param endDate - Fine della finestra misurata (inclusa)
+ */
+function resolveBaseAwareCashFlows(
+  expenseFlows: CashFlowData[],
+  portfolioFlows: CashFlowData[] | undefined,
+  startDate: Date,
+  endDate: Date
+): { cashFlows: CashFlowData[]; flowSource: PerformanceMetrics['flowSource'] } {
+  const measured = (portfolioFlows ?? []).filter(cf => cf.date >= startDate && cf.date <= endDate);
+  const measuredMonths = new Set(measured.map(cf => monthKeyOf(cf.date)));
+  const fallback = portfolioFlows
+    ? expenseFlows.filter(cf => !measuredMonths.has(monthKeyOf(cf.date)))
+    : expenseFlows;
+  const cashFlows = portfolioFlows
+    ? [...measured, ...fallback].sort((a, b) => a.date.getTime() - b.date.getTime())
+    : expenseFlows;
+
+  // Dichiarare la sorgente per PERIODO sarebbe una semplificazione bugiarda quando le due
+  // convivono: la tessera Contributi deve poter dire «in parte».
+  const flowSource: PerformanceMetrics['flowSource'] = !portfolioFlows
+    ? 'cashflow'
+    : fallback.length === 0
+      ? 'portfolio'
+      : measured.length === 0
+        ? 'cashflow'
+        : 'mixed';
+
+  return { cashFlows, flowSource };
+}
+
+/**
  * Calculate performance metrics for a specific time period
  *
  * @param preFetchedExpenses - Optional pre-fetched expenses array to avoid redundant Firestore queries
@@ -1103,30 +1157,9 @@ export async function calculatePerformanceForPeriod(
     ? getCashFlowsFromExpenses(preFetchedExpenses, startDate, endDate, dividendCategoryId)
     : await getCashFlowsForPeriod(userId, startDate, endDate, dividendCategoryId);
 
-  // I FLUSSI SEGUONO LA BASE (fix D1, 2026-08-30), **mese per mese**.
-  //
-  // `portfolioFlows` porta una voce per ogni mese MISURABILE (serve il `byAsset` di entrambi i mesi
-  // della coppia), zeri compresi. Un mese assente non e' un mese a flusso nullo: e' un mese che non
-  // si puo' misurare, e li' si ricade sul Cashflow. Senza questo fallback uno storico fatto di
-  // snapshot inseriti a mano — nessun breakdown — finirebbe con flussi tutti nulli e ogni
-  // versamento verrebbe letto come rendimento: una regressione grave e silenziosa rispetto al
-  // comportamento precedente.
-  const measured = (portfolioFlows ?? []).filter(cf => cf.date >= startDate && cf.date <= endDate);
-  const measuredMonths = new Set(measured.map(cf => monthKeyOf(cf.date)));
-  const fallback = portfolioFlows
-    ? expenseFlows.filter(cf => !measuredMonths.has(monthKeyOf(cf.date)))
-    : expenseFlows;
-  const cashFlows = portfolioFlows ? [...measured, ...fallback].sort((a, b) => a.date.getTime() - b.date.getTime()) : expenseFlows;
-
-  // Dichiarare la sorgente per PERIODO sarebbe una semplificazione bugiarda quando le due
-  // convivono: la tessera Contributi deve poter dire «in parte».
-  const flowSource: PerformanceMetrics['flowSource'] = !portfolioFlows
-    ? 'cashflow'
-    : fallback.length === 0
-      ? 'portfolio'
-      : measured.length === 0
-        ? 'cashflow'
-        : 'mixed';
+  // I flussi che neutralizzano il rendimento seguono la base — la regola sta tutta in
+  // resolveBaseAwareCashFlows, condivisa con le finestre rolling.
+  const { cashFlows, flowSource } = resolveBaseAwareCashFlows(expenseFlows, portfolioFlows, startDate, endDate);
 
   // Entrate/uscite/dividendi vengono SEMPRE dal Cashflow: un acquisto non e' ne' uno stipendio ne'
   // una spesa, e sommarlo li' mescolerebbe due perimetri.
@@ -1310,7 +1343,6 @@ function serializePerformanceData(data: PerformanceData): FirestorePerformanceDa
     fiveYear: serializeMetrics(data.fiveYear),
     allTime: serializeMetrics(data.allTime),
     rolling12M: data.rolling12M.map(serializeRolling),
-    rolling36M: data.rolling36M.map(serializeRolling),
     lastUpdated: Timestamp.fromDate(data.lastUpdated),
     snapshotCount: data.snapshotCount,
   };
@@ -1325,7 +1357,6 @@ function deserializePerformanceData(raw: FirestorePerformanceData): PerformanceD
     allTime: deserializeMetrics(raw.allTime),
     custom: null,
     rolling12M: raw.rolling12M.map(deserializeRolling),
-    rolling36M: raw.rolling36M.map(deserializeRolling),
     lastUpdated: raw.lastUpdated.toDate(),
     snapshotCount: raw.snapshotCount,
   };
@@ -1580,8 +1611,8 @@ export async function getAllPerformanceData(userId: string, forceRefresh = false
   ]);
 
   // ==== STEP 5: Calculate rolling periods (reuse allExpenses — no extra Firestore queries) ====
-  const rolling12M = await calculateRollingPeriods(userId, snapshots, 12, riskFreeRate, dividendCategoryId, allExpenses);
-  const rolling36M = await calculateRollingPeriods(userId, snapshots, 36, riskFreeRate, dividendCategoryId, allExpenses);
+  // `portfolioFlows` come per i periodi fissi: stessa base, stessi flussi, una sola risposta.
+  const rolling12M = await calculateRollingPeriods(userId, snapshots, 12, riskFreeRate, dividendCategoryId, allExpenses, portfolioFlows);
 
   const result: PerformanceData = {
     ytd,
@@ -1591,7 +1622,6 @@ export async function getAllPerformanceData(userId: string, forceRefresh = false
     allTime,
     custom: null,
     rolling12M,
-    rolling36M,
     lastUpdated: new Date(),
     snapshotCount: snapshots.length,
   };
@@ -1616,6 +1646,14 @@ export async function getAllPerformanceData(userId: string, forceRefresh = false
  *
  * Uses in-memory filtering of pre-fetched expenses to avoid N Firestore queries.
  *
+ * I FLUSSI SEGUONO LA BASE anche qui. Gli snapshot arrivano gia' proiettati sulla base
+ * (`toPerformanceBaseSnapshots`), quindi il capitale misurato e' quello giusto; senza
+ * `portfolioFlows` pero' i flussi resterebbero quelli del Cashflow, dimensionati sull'intero
+ * patrimonio, e ogni finestra sottrarrebbe da un capitale ridotto i versamenti di tutto il
+ * patrimonio. E' la stessa coppia capitale/flussi dei cinque periodi fissi — vedi
+ * `resolveBaseAwareCashFlows` — e senza di essa le rolling divergono dai numeri delle tessere
+ * mostrate sopra, nella stessa pagina.
+ *
  * ASSUMPTION: snapshots are monthly and contiguous, so `windowMonths + 1` snapshots span
  * `windowMonths` measured months. It is the same assumption the index arithmetic below already
  * makes; with a hole in the series a window would cover more calendar time than its name says.
@@ -1625,6 +1663,9 @@ export async function getAllPerformanceData(userId: string, forceRefresh = false
  * @param windowMonths - Size of the rolling window in months
  * @param riskFreeRate - Risk-free rate for Sharpe ratio calculation
  * @param dividendCategoryId - Category ID for dividend income (from user settings)
+ * @param prefetchedExpenses - Spese gia' lette, per evitare una query per finestra
+ * @param portfolioFlows - I flussi per asset di `buildPortfolioCashFlows`, o `undefined` quando la
+ *   base e' tutto il patrimonio (nessuna esclusione) e il Cashflow e' la fonte giusta
  * @returns Array of rolling period performance data
  */
 export async function calculateRollingPeriods(
@@ -1633,7 +1674,8 @@ export async function calculateRollingPeriods(
   windowMonths: number,
   riskFreeRate: number,
   dividendCategoryId?: string,
-  prefetchedExpenses?: Expense[]
+  prefetchedExpenses?: Expense[],
+  portfolioFlows?: CashFlowData[]
 ): Promise<RollingPeriodPerformance[]> {
   const sortedSnapshots = [...allSnapshots]
     .sort((a, b) => {
@@ -1669,7 +1711,11 @@ export async function calculateRollingPeriods(
     // Get snapshots and cash flows for this window
     const windowSnapshots = sortedSnapshots.slice(i - windowMonths, i + 1);
     // OPTIMIZATION: Use in-memory filtering instead of Firestore query
-    const cashFlows = getCashFlowsFromExpenses(allExpenses, periodStartDate, periodEndDate, dividendCategoryId);
+    const expenseFlows = getCashFlowsFromExpenses(allExpenses, periodStartDate, periodEndDate, dividendCategoryId);
+    // Le date coincidono per costruzione: `buildPortfolioCashFlows` data ogni voce al 1° del mese
+    // e `periodStartDate` e' il 1° del mese successivo alla valutazione, la stessa convenzione del
+    // ramo per periodo.
+    const { cashFlows } = resolveBaseAwareCashFlows(expenseFlows, portfolioFlows, periodStartDate, periodEndDate);
 
     // Calculate CAGR
     const netCashFlow = cashFlows.reduce((sum, cf) => sum + cf.netCashFlow, 0);
@@ -1692,7 +1738,10 @@ export async function calculateRollingPeriods(
     rollingPeriods.push({
       periodEndDate,
       periodStartDate,
-      cagr: cagr || 0,
+      // `?? null`, mai `|| 0`: un CAGR non misurabile non e' un rendimento nullo, e uno zero
+      // legittimo (la finestra e' finita dov'era partita) e' un rendimento vero da non schiacciare.
+      // Sharpe e volatilita' qui sotto sono `null` per lo stesso motivo da sempre.
+      cagr: cagr ?? null,
       sharpeRatio,
       volatility,
     });

--- a/lib/services/performanceService.ts
+++ b/lib/services/performanceService.ts
@@ -22,7 +22,9 @@ import { getExpensesByDateRange } from './expenseService';
 import { getUserSnapshots } from './snapshotService';
 import { getSettings } from './assetAllocationService';
 import { getAllAssets } from './assetService';
-import { buildCashFlowMap, monthKey } from '@/lib/utils/cashFlowMap';
+import { buildCashFlowMap, monthKey, monthKeyOf } from '@/lib/utils/cashFlowMap';
+import { buildPortfolioCashFlows } from '@/lib/utils/portfolioFlows';
+import { getAssetTransactions } from '@/lib/services/assetTransactionService';
 import { endOfMonthBound } from '@/lib/utils/dateHelpers';
 import { computeDividendYieldMetrics } from '@/lib/utils/yieldOnCost';
 import { buildTwrIndex, computeDrawdownSeries, findMaxDrawdown } from '@/lib/utils/drawdownSeries';
@@ -47,7 +49,7 @@ const PERFORMANCE_CACHE_COLLECTION = 'performance-cache';
  * TWR annualization; v3 = rolling windows; v4 = IRR signs and timeline; v5 = volatility without
  * the ±50% filter, and its 3-observation floor.
  */
-const CACHE_MATH_VERSION = 'v5';
+const CACHE_MATH_VERSION = 'v6';
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -101,7 +103,11 @@ export function calculateROI(
   endNW: number,
   netCashFlow: number
 ): number | null {
-  if (startNW === 0) return null;
+  // `<= 0`, non `=== 0`: un capitale iniziale nullo O NEGATIVO non ha un rendimento percentuale.
+  // Diventa raggiungibile con una storia lunga — un mese interamente liquidato, o saldi netti
+  // negativi (crediti/debiti) — e un denominatore negativo non fallisce: ribalta il segno in
+  // silenzio, che e' il modo peggiore di sbagliare.
+  if (startNW <= 0) return null;
 
   const gain = endNW - startNW - netCashFlow;
   return (gain / startNW) * 100;
@@ -176,7 +182,8 @@ export function calculateTimeWeightedReturn(
     const cashFlow = cashFlowMap.get(monthKey(currSnapshot.year, currSnapshot.month)) || 0;
 
     // Calculate sub-period return: (End NW - Cash Flow) / Start NW - 1
-    if (startNW === 0) continue; // Skip if zero starting value
+    // Vedi la nota su `<= 0` in calculateROI: nullo o negativo, non c'e' rendimento da misurare.
+    if (startNW <= 0) continue;
     const periodReturn = ((endNW - cashFlow) / startNW) - 1;
 
     // Link returns geometrically
@@ -300,7 +307,7 @@ export function calculateIRR(
   numberOfMonths: number,
   periodStart: Date
 ): number | null {
-  if (numberOfMonths < 1 || startNW === 0) return null;
+  if (numberOfMonths < 1 || startNW <= 0) return null;
 
   const flows: DatedFlow[] = [{ amount: -startNW, monthsFromStart: 0 }];
 
@@ -409,7 +416,7 @@ export function calculateVolatility(
     const prevNW = snapshots[i - 1].totalNetWorth;
     const currNW = snapshots[i].totalNetWorth;
 
-    if (prevNW === 0) continue;
+    if (prevNW <= 0) continue;
 
     const cashFlow = cashFlowMap.get(monthKey(snapshots[i].year, snapshots[i].month)) || 0;
 
@@ -976,7 +983,14 @@ export async function calculatePerformanceForPeriod(
   customStartDate?: Date,
   customEndDate?: Date,
   preFetchedExpenses?: Expense[],
-  dividendCategoryId?: string
+  dividendCategoryId?: string,
+  /**
+   * I flussi del portafoglio (variazioni di quantita'), calcolati UNA volta su tutta la storia da
+   * `buildPortfolioCashFlows` e passati qui gia' pronti. Presenti = la base esclude qualcosa, quindi
+   * un acquisto attraversa il confine ed e' un flusso; assenti = la base e' tutto il patrimonio e i
+   * flussi restano quelli del Cashflow. Vedi `lib/utils/portfolioFlows.ts`.
+   */
+  portfolioFlows?: CashFlowData[]
 ): Promise<PerformanceMetrics> {
   // One clock for the whole computation: period selection, the nominal start recorded in the
   // payload and the dividend cap must not disagree because they each called new Date().
@@ -1019,6 +1033,7 @@ export async function calculatePerformanceForPeriod(
     totalContributions: 0,
     totalWithdrawals: 0,
     netCashFlow: 0,
+    flowSource: 'cashflow',
     totalIncome: 0,
     totalExpenses: 0,
     totalDividendIncome: 0,
@@ -1082,25 +1097,53 @@ export async function calculatePerformanceForPeriod(
     return baseMetrics;
   }
 
-  // Get cash flows for period - use pre-fetched if available, otherwise fetch
-  const cashFlows = preFetchedExpenses
+  // I flussi del Cashflow servono comunque: entrate, uscite e dividendi del periodo sono contesto
+  // che la tessera Contributi mostra, e restano quelli anche quando la base e' il solo portafoglio.
+  const expenseFlows = preFetchedExpenses
     ? getCashFlowsFromExpenses(preFetchedExpenses, startDate, endDate, dividendCategoryId)
     : await getCashFlowsForPeriod(userId, startDate, endDate, dividendCategoryId);
 
-  // Calculate net cash flow totals
-  let totalContributions = 0;
-  let totalWithdrawals = 0;
+  // I FLUSSI SEGUONO LA BASE (fix D1, 2026-08-30), **mese per mese**.
+  //
+  // `portfolioFlows` porta una voce per ogni mese MISURABILE (serve il `byAsset` di entrambi i mesi
+  // della coppia), zeri compresi. Un mese assente non e' un mese a flusso nullo: e' un mese che non
+  // si puo' misurare, e li' si ricade sul Cashflow. Senza questo fallback uno storico fatto di
+  // snapshot inseriti a mano — nessun breakdown — finirebbe con flussi tutti nulli e ogni
+  // versamento verrebbe letto come rendimento: una regressione grave e silenziosa rispetto al
+  // comportamento precedente.
+  const measured = (portfolioFlows ?? []).filter(cf => cf.date >= startDate && cf.date <= endDate);
+  const measuredMonths = new Set(measured.map(cf => monthKeyOf(cf.date)));
+  const fallback = portfolioFlows
+    ? expenseFlows.filter(cf => !measuredMonths.has(monthKeyOf(cf.date)))
+    : expenseFlows;
+  const cashFlows = portfolioFlows ? [...measured, ...fallback].sort((a, b) => a.date.getTime() - b.date.getTime()) : expenseFlows;
+
+  // Dichiarare la sorgente per PERIODO sarebbe una semplificazione bugiarda quando le due
+  // convivono: la tessera Contributi deve poter dire «in parte».
+  const flowSource: PerformanceMetrics['flowSource'] = !portfolioFlows
+    ? 'cashflow'
+    : fallback.length === 0
+      ? 'portfolio'
+      : measured.length === 0
+        ? 'cashflow'
+        : 'mixed';
+
+  // Entrate/uscite/dividendi vengono SEMPRE dal Cashflow: un acquisto non e' ne' uno stipendio ne'
+  // una spesa, e sommarlo li' mescolerebbe due perimetri.
   let totalIncome = 0;
   let totalExpenses = 0;
   let totalDividendIncome = 0;
-
-  cashFlows.forEach(cf => {
-    // Sum all income and expenses (dividends tracked separately)
+  expenseFlows.forEach(cf => {
     totalIncome += cf.income;
     totalExpenses += cf.expenses;
     totalDividendIncome += cf.dividendIncome;
+  });
 
-    // Calculate contributions/withdrawals based on net cash flow (WITHOUT dividends)
+  // Contributi e prelievi sono invece la serie che neutralizza il rendimento, cioe' quella scelta
+  // sopra: e' lo stesso denaro che TWR toglie dal numeratore.
+  let totalContributions = 0;
+  let totalWithdrawals = 0;
+  cashFlows.forEach(cf => {
     if (cf.netCashFlow > 0) {
       totalContributions += cf.netCashFlow;
     } else {
@@ -1202,6 +1245,7 @@ export async function calculatePerformanceForPeriod(
     totalContributions,
     totalWithdrawals,
     netCashFlow,
+    flowSource,
     totalIncome,
     totalExpenses,
     totalDividendIncome,
@@ -1382,13 +1426,23 @@ export function buildCacheKey(inputs: {
   baseOptions: PerformanceBaseOptions;
   riskFreeRate: number;
   dividendCategoryId?: string;
+  /**
+   * Le operazioni del registro. Da quando i flussi le preferiscono alle Delta-quantita'
+   * (portfolioFlows.ts) sono un INPUT dei numeri: senza la firma, registrare una vendita non
+   * cambierebbe la chiave e la pagina resterebbe sui valori vecchi fino alla scadenza delle 6 ore.
+   */
+  ledgerTrades?: Array<{ id: string; date: Date }>;
 }): string {
-  const { snapshots, baseOptions, riskFreeRate, dividendCategoryId } = inputs;
+  const { snapshots, baseOptions, riskFreeRate, dividendCategoryId, ledgerTrades = [] } = inputs;
 
   const baseSignature = `p${baseOptions.includePensionFunds ? 1 : 0}e${baseOptions.includeExcludedAssets ? 1 : 0}`;
   const settingsSignature = `r${riskFreeRate}d${dividendCategoryId ?? 'none'}`;
+  // Conteggio + operazione piu' recente: un'aggiunta, una cancellazione o una data spostata
+  // cambiano almeno uno dei due.
+  const lastTrade = ledgerTrades.reduce((latest, t) => (t.date > latest ? t.date : latest), new Date(0));
+  const ledgerSignature = `l${ledgerTrades.length}t${lastTrade.getTime()}`;
 
-  if (snapshots.length === 0) return `${CACHE_MATH_VERSION}-0-${baseSignature}-${settingsSignature}`;
+  if (snapshots.length === 0) return `${CACHE_MATH_VERSION}-0-${baseSignature}-${settingsSignature}-${ledgerSignature}`;
 
   const last = snapshots.reduce((latest, s) =>
     s.year !== latest.year ? (s.year > latest.year ? s : latest) : s.month > latest.month ? s : latest
@@ -1402,6 +1456,7 @@ export function buildCacheKey(inputs: {
     hashSnapshotSeries(snapshots),
     baseSignature,
     settingsSignature,
+    ledgerSignature,
   ].join('-');
 }
 
@@ -1422,10 +1477,27 @@ export function buildCacheKey(inputs: {
  */
 export async function getAllPerformanceData(userId: string, forceRefresh = false): Promise<PerformanceData> {
   // ==== STEP 1: Fetch snapshots, settings, and assets in parallel ====
-  const [rawSnapshots, settings, assets] = await Promise.all([
+  const [rawSnapshots, settings, assets, ledgerTrades] = await Promise.all([
     getUserSnapshots(userId),
     getSettings(userId),
     getAllAssets(userId),
+    // Il registro operazioni e' la fonte PREFERITA dei flussi, per asset — vedi portfolioFlows.ts.
+    // Vuoto (registro mai aperto) non e' un errore: si ricade tutto sulle Delta-quantita'.
+    //
+    // Va letto PRIMA del controllo di cache, perche' entra nella chiave: senza, registrare una
+    // vendita non invaliderebbe i numeri. E' una query indicizzata in piu' per caricamento, che si
+    // sovrappone a quella che la pagina fa gia' con React Query — il prezzo di non servire numeri
+    // stantii dopo un'operazione.
+    getAssetTransactions(userId).catch((error) => {
+      // Degradare in silenzio significherebbe misurare con le sole Delta-quantita' senza che
+      // nessuno lo sappia: meno preciso e indistinguibile da un registro vuoto.
+      console.warn('Rendimenti: registro operazioni non leggibile, i flussi useranno le sole variazioni di quantità', {
+        userId,
+        error,
+        operation: 'getAllPerformanceData',
+      });
+      return [];
+    }),
   ]);
 
   // Rendimenti measures the ACTIVELY MANAGED portfolio: pension funds (illiquid, fed by
@@ -1437,10 +1509,28 @@ export async function getAllPerformanceData(userId: string, forceRefresh = false
   // chart/heatmap/custom-range helpers. Keep the options in sync or a custom period silently
   // disagrees with the pre-computed YTD/1Y/3Y/5Y/ALL metrics.
   const baseOptions = resolvePerformanceBaseOptions(settings);
-  const snapshots = toPerformanceBaseSnapshots(
-    rawSnapshots,
-    resolvePerformanceExclusions(assets, baseOptions)
-  );
+  const exclusions = resolvePerformanceExclusions(assets, baseOptions);
+  const snapshots = toPerformanceBaseSnapshots(rawSnapshots, exclusions);
+
+  // I FLUSSI SEGUONO LA BASE (fix D1, 2026-08-30).
+  //
+  // La condizione e' `exclusions.length > 0`, cioe' «la base e' davvero un sottoinsieme del
+  // patrimonio». Senza esclusioni `toPerformanceBaseSnapshots` restituisce gli snapshot intatti: la
+  // base E' il patrimonio, solo il denaro esterno la cambia, e la domanda e' esattamente quella del
+  // Cashflow. Cambiare fonte li' sarebbe un peggioramento gratuito per la maggioranza degli account.
+  //
+  // Con qualcosa fuori base, invece, un trasferimento che attraversa il confine non e' piu' a saldo
+  // zero sul capitale misurato — e il Cashflow non puo' vederlo, salta i trasferimenti per
+  // costruzione. Nota che la somma per asset si comporta bene anche con la liquidita' DENTRO la
+  // base: l'ETF fa +X e il conto -X, e si annullano da soli.
+  //
+  // I fondi pensione tengono il valore in `quantity` con prezzo 1, quindi una loro Delta-quantita'
+  // non distingue un versamento da un rendimento: restano opachi al ramo Delta-quantita'.
+  const flowOpaqueAssetIds = assets.filter((a) => a.type === 'pensionFund').map((a) => a.id);
+  const portfolioFlows =
+    exclusions.length > 0
+      ? buildPortfolioCashFlows(snapshots, exclusions, ledgerTrades, flowOpaqueAssetIds)
+      : undefined;
 
   // `??`, not `||`: a deliberate 0% risk-free rate is a legitimate setting (it makes Sharpe the raw
   // return over volatility) and must not be silently replaced by the 2.5% default.
@@ -1450,7 +1540,7 @@ export async function getAllPerformanceData(userId: string, forceRefresh = false
   // ==== STEP 2: Check cache before fetching expenses ====
   // The key fingerprints every input the numbers depend on — see buildCacheKey for the full list
   // and for what a stale hit costs. On a hit we skip the expensive whole-history expense fetch.
-  const cacheKey = buildCacheKey({ snapshots, baseOptions, riskFreeRate, dividendCategoryId });
+  const cacheKey = buildCacheKey({ snapshots, baseOptions, riskFreeRate, dividendCategoryId, ledgerTrades });
   if (!forceRefresh) {
     const cached = await readPerformanceCache(userId);
     if (cached && cached.cacheKey === cacheKey) {
@@ -1482,11 +1572,11 @@ export async function getAllPerformanceData(userId: string, forceRefresh = false
 
   // ==== STEP 4: Calculate metrics for all time periods ====
   const [ytd, oneYear, threeYear, fiveYear, allTime] = await Promise.all([
-    calculatePerformanceForPeriod(userId, snapshots, 'YTD', riskFreeRate, undefined, undefined, allExpenses, dividendCategoryId),
-    calculatePerformanceForPeriod(userId, snapshots, '1Y', riskFreeRate, undefined, undefined, allExpenses, dividendCategoryId),
-    calculatePerformanceForPeriod(userId, snapshots, '3Y', riskFreeRate, undefined, undefined, allExpenses, dividendCategoryId),
-    calculatePerformanceForPeriod(userId, snapshots, '5Y', riskFreeRate, undefined, undefined, allExpenses, dividendCategoryId),
-    calculatePerformanceForPeriod(userId, snapshots, 'ALL', riskFreeRate, undefined, undefined, allExpenses, dividendCategoryId),
+    calculatePerformanceForPeriod(userId, snapshots, 'YTD', riskFreeRate, undefined, undefined, allExpenses, dividendCategoryId, portfolioFlows),
+    calculatePerformanceForPeriod(userId, snapshots, '1Y', riskFreeRate, undefined, undefined, allExpenses, dividendCategoryId, portfolioFlows),
+    calculatePerformanceForPeriod(userId, snapshots, '3Y', riskFreeRate, undefined, undefined, allExpenses, dividendCategoryId, portfolioFlows),
+    calculatePerformanceForPeriod(userId, snapshots, '5Y', riskFreeRate, undefined, undefined, allExpenses, dividendCategoryId, portfolioFlows),
+    calculatePerformanceForPeriod(userId, snapshots, 'ALL', riskFreeRate, undefined, undefined, allExpenses, dividendCategoryId, portfolioFlows),
   ]);
 
   // ==== STEP 5: Calculate rolling periods (reuse allExpenses — no extra Firestore queries) ====
@@ -1709,7 +1799,7 @@ export function prepareMonthlyReturnsHeatmap(
     const startNW = prevSnapshot.totalNetWorth;
     const endNW = currSnapshot.totalNetWorth;
 
-    if (startNW === 0) continue; // Skip if zero starting value
+    if (startNW <= 0) continue;
 
     // Get cash flow for current month
     const cfKey = monthKey(currSnapshot.year, currSnapshot.month);

--- a/lib/utils/drawdownSeries.ts
+++ b/lib/utils/drawdownSeries.ts
@@ -73,7 +73,9 @@ export function buildTwrIndex(
     const startNetWorth = snapshots[i - 1].totalNetWorth;
     const snapshot = snapshots[i];
 
-    if (startNetWorth !== 0) {
+    // `> 0`, non `!== 0`: un capitale di partenza negativo (mese liquidato, saldi netti negativi)
+    // ribalterebbe il segno del rapporto e farebbe scendere l'indice mentre il portafoglio sale.
+    if (startNetWorth > 0) {
       const cashFlow = cashFlowMap.get(monthKey(snapshot.year, snapshot.month)) ?? 0;
       index *= (snapshot.totalNetWorth - cashFlow) / startNetWorth;
     }

--- a/lib/utils/performanceNarrative.ts
+++ b/lib/utils/performanceNarrative.ts
@@ -440,27 +440,46 @@ export function describeConsistency(c: ReturnConsistency): Narrative {
 }
 
 /**
- * Two figures that measure two different things, side by side on purpose: the ledger's buys minus
- * sells and the cashflow's income minus spending. Without the ledger the reading says so.
+ * Two figures that measure two different things, side by side on purpose: the capital that went
+ * into the instruments and the cashflow's income minus spending.
+ *
+ * Where the first figure comes from depends on `flowSource` — I FLUSSI SEGUONO LA BASE. Con
+ * `portfolio` (o `mixed`) è la serie MISURATA (`portfolioFlows.ts`), cioè esattamente quella che il
+ * rendimento ha neutralizzato; con `cashflow` la base è tutto il patrimonio e il capitale investito
+ * può solo venire dal registro operazioni, che potrebbe non essere attivo.
  */
 export function describeContributions(input: {
   invested: { investedEur: number; divestedEur: number; netInvestedEur: number } | null;
   netCashFlow: number;
+  flowSource: 'portfolio' | 'cashflow' | 'mixed';
+  /** Entrate meno uscite del Cashflow: il risparmio, sempre e comunque. */
+  cashflowNet: number;
 }): Narrative {
-  const cashflowClause: Narrative =
-    input.netCashFlow >= 0
-      ? [figure(euro(input.netCashFlow)), prose(' messi da parte')]
-      : [prose('dal cashflow sono usciti '), figure(euro(input.netCashFlow)), prose(' più di quanto è entrato')];
+  const savingsClause: Narrative =
+    input.cashflowNet >= 0
+      ? [figure(euro(input.cashflowNet)), prose(' messi da parte')]
+      : [prose('dal cashflow sono usciti '), figure(euro(input.cashflowNet)), prose(' più di quanto è entrato')];
+
+  if (input.flowSource === 'portfolio' || input.flowSource === 'mixed') {
+    const net = input.netCashFlow;
+    const out: Narrative = [
+      prose(net >= 0 ? 'Sono entrati ' : 'Sono usciti '),
+      figure(euro(net)),
+      prose(net >= 0 ? ' negli strumenti' : ' dagli strumenti'),
+    ];
+    out.push(prose(input.cashflowNet >= 0 ? ', a fronte di ' : ', mentre '), ...savingsClause, prose('.'));
+    return out;
+  }
 
   if (!input.invested) {
-    return input.netCashFlow >= 0
-      ? [prose('Dal cashflow hai messo da parte '), figure(euro(input.netCashFlow)), prose(' nel periodo; il registro operazioni non è attivo.')]
-      : [prose('Dal cashflow sono usciti '), figure(euro(input.netCashFlow)), prose(' più di quanto è entrato nel periodo; il registro operazioni non è attivo.')];
+    return input.cashflowNet >= 0
+      ? [prose('Dal cashflow hai messo da parte '), figure(euro(input.cashflowNet)), prose(' nel periodo; il registro operazioni non è attivo.')]
+      : [prose('Dal cashflow sono usciti '), figure(euro(input.cashflowNet)), prose(' più di quanto è entrato nel periodo; il registro operazioni non è attivo.')];
   }
 
   const net = input.invested.netInvestedEur;
   const out: Narrative = [prose(net >= 0 ? 'Hai investito ' : 'Hai disinvestito '), figure(euro(net)), prose(' dal registro')];
-  out.push(prose(input.netCashFlow >= 0 ? ', a fronte di ' : ', mentre '), ...cashflowClause, prose('.'));
+  out.push(prose(input.cashflowNet >= 0 ? ', a fronte di ' : ', mentre '), ...savingsClause, prose('.'));
   return out;
 }
 

--- a/lib/utils/portfolioFlows.ts
+++ b/lib/utils/portfolioFlows.ts
@@ -1,0 +1,230 @@
+/**
+ * portfolioFlows — i flussi che attraversano il confine della base dei Rendimenti.
+ *
+ * IL DIFETTO CHE QUESTO MODULO CHIUDE
+ * `getCashFlowsFromExpenses` risponde a «quanto denaro è entrato nel patrimonio dall'esterno»:
+ * entrate meno uscite del Cashflow, con i trasferimenti **saltati per costruzione** (sono
+ * net-zero sul patrimonio). È la risposta giusta quando la base è tutto il patrimonio.
+ *
+ * Non lo è quando la base è il solo portafoglio gestito. Lì la liquidità sta FUORI dalla base, e
+ * comprare un ETF con i soldi di un conto è denaro che **entra** nella base — un trasferimento,
+ * cioè esattamente ciò che quella funzione non può vedere. Sui dati reali dell'account, febbraio →
+ * agosto 2026, questo valeva 35.208 € di acquisti letti come rendimento, contro 659 € di flussi
+ * effettivamente neutralizzati: la pagina raddoppiava il rendimento (audit del 2026-08-29, D1).
+ *
+ * LA REGOLA: I FLUSSI SEGUONO LA BASE
+ * Base `netWorth` (nulla è escluso) → i flussi restano quelli del Cashflow: solo il denaro che
+ * entra dall'esterno cambia il capitale misurato.
+ * Base `portfolio` (qualcosa è escluso) → i flussi sono le variazioni di **quantità** degli
+ * strumenti dentro la base, valorizzate al prezzo del mese: `Σ (q₁ − q₀) × p₁`. Una quantità che
+ * cresce è capitale entrato, una che cala è capitale uscito, e il prezzo non c'entra — che è
+ * precisamente la definizione di flusso che TWR vuole al numeratore.
+ *
+ * IL REGISTRO PRIMA, LE QUANTITÀ COME RETE — **per asset, non per data**
+ * Il registro operazioni è la fonte migliore dove esiste: è datato all'OPERAZIONE, mentre uno
+ * snapshot è datato alla rilevazione. Sull'account reale la differenza si vede — 722 quote NTSG
+ * comprate il 20/08/2025 stanno nel registro ad agosto e nello snapshot a settembre — e sull'ordine
+ * ha ragione il registro.
+ *
+ * Ma il registro da solo non regge la storia, perché conosce solo ciò che è stato registrato. Ad
+ * aprile 2025 registra l'acquisto del portafoglio nuovo (30.065 €) e non la vendita del vecchio,
+ * che stava su un altro intermediario: preso da solo quel mese vale **−100%**. Le quantità degli
+ * snapshot, invece, non possono mancare un'operazione — se la posizione è cambiata, la quantità lo
+ * dice — ma sbagliano il mese al confine.
+ *
+ * Nessuna delle due, da sola, ci arriva. La regola è quindi **per asset**:
+ *   - l'asset ha operazioni registrate, e il mese è dal suo primo movimento in poi → **registro**;
+ *   - altrimenti → **Δquantità**.
+ * Aprile 2025 torna esatto proprio così: MWEQ e SWDA dal registro (+30.065), i cinque strumenti del
+ * vecchio intermediario dalle quantità (−20.322), flusso netto +9.743.
+ *
+ * La conseguenza che conta è sul FUTURO: un utente che registra le sue operazioni ha ogni asset
+ * coperto, quindi la misura è interamente basata sul registro e le quantità non intervengono mai.
+ * La rete serve al passato, non lo zavorra.
+ *
+ * I LIMITI, DICHIARATI
+ *  - **Δquantità: prezzo di fine mese, non di operazione.** Un acquisto a metà mese è valorizzato al
+ *    prezzo di chiusura: giusto in quantità, approssimato in euro. È la convenzione «flusso a fine
+ *    periodo», la stessa che il resto della pipeline già assume. Non riguarda il ramo registro.
+ *  - **Δquantità: una variazione di quantità non è sempre un'operazione.** Split, fusioni,
+ *    conferimenti in natura e dividendi reinvestiti in quote muovono le quantità senza denaro, e
+ *    verrebbero letti come versamenti.
+ *  - **Registro: un'operazione non registrata sparisce.** Per un asset marcato come coperto le
+ *    Δquantità non intervengono più, quindi una vendita dimenticata sottostima il flusso e gonfia il
+ *    rendimento. È il prezzo di preferire il registro, e la guardia naturale sarebbe una
+ *    riconciliazione fra le due fonti — non c'è ancora.
+ *
+ * QUANDO IL FLUSSO NON È MISURABILE
+ * Serve il `byAsset` di ENTRAMBI i mesi di una coppia: senza, non c'è modo di sapere se una
+ * variazione di valore fosse un acquisto o il mercato. Quel mese non produce una voce — e
+ * l'assenza è un'informazione, non uno zero. Chi consuma questi flussi deve ricadere sul Cashflow
+ * per i mesi assenti, altrimenti uno storico fatto di snapshot inseriti a mano (nessun `byAsset`)
+ * finirebbe con flussi nulli e ogni versamento verrebbe letto come rendimento. Un mese misurato in
+ * cui non si è mosso niente vale invece **zero**, ed è una voce a tutti gli effetti: le due cose
+ * non vanno confuse.
+ *
+ * GLI ASSET OPACHI AL FLUSSO
+ * Per alcuni asset la quantità non conta unità ma **valore**, e cresce sia per i versamenti sia per
+ * il mercato: un fondo pensione tiene il suo valore in `quantity` con prezzo 1
+ * (`assertFundValueLivesInQuantity`). Su questi una Δquantità non distingue un versamento da un
+ * rendimento, e leggerla come flusso cancellerebbe il rendimento del fondo. Vanno passati in
+ * `flowOpaqueAssetIds`: contribuiscono 0 al ramo Δquantità (i loro versamenti restano non
+ * neutralizzati — è la limitazione storica del modulo, non una regressione). Un conto corrente NON
+ * è opaco: lì la quantità è il saldo, e una sua variazione è davvero denaro che si muove.
+ */
+
+import type { MonthlySnapshot } from '@/types/assets';
+import type { AssetTransaction } from '@/types/assetTransactions';
+import type { CashFlowData } from '@/types/performance';
+import { hasAssetBreakdown } from '@/lib/utils/snapshotAssetBreakdown';
+import { monthKey } from '@/lib/utils/cashFlowMap';
+
+/** Le posizioni di un mese, indicizzate per `assetId`, senza gli asset fuori base. */
+function positionsInBase(
+  snapshot: MonthlySnapshot,
+  excludedIds: Set<string>
+): Map<string, { quantity: number; price: number }> {
+  const out = new Map<string, { quantity: number; price: number }>();
+  for (const entry of snapshot.byAsset) {
+    if (excludedIds.has(entry.assetId)) continue;
+    const previous = out.get(entry.assetId);
+    // Uno stesso assetId due volte nello stesso mese non dovrebbe esistere; se esiste, si somma
+    // invece di tenere in silenzio solo l'ultima (stessa scelta di `buildCashFlowMap`).
+    out.set(entry.assetId, {
+      quantity: (previous?.quantity ?? 0) + entry.quantity,
+      price: entry.price,
+    });
+  }
+  return out;
+}
+
+/**
+ * Il registro, indicizzato per l'uso che ne fa il flusso: quanto denaro un asset ha mosso in un
+ * mese, e da quale mese quell'asset e' coperto.
+ *
+ * Un `adjustment` non muove denaro (e' una rettifica di quantita'), quindi non entra nel flusso —
+ * ma conta come copertura: l'asset e' comunque tracciato nel registro.
+ *
+ * @param trades - Le operazioni dell'account, in qualsiasi ordine
+ * @returns `flows` = `assetId|YYYY-MM` → euro netti (acquisti positivi, vendite negative);
+ *   `coveredFrom` = `assetId` → il mese della sua prima operazione
+ */
+export function indexLedger(trades: AssetTransaction[]): {
+  flows: Map<string, number>;
+  coveredFrom: Map<string, string>;
+} {
+  const flows = new Map<string, number>();
+  const coveredFrom = new Map<string, string>();
+
+  for (const trade of trades) {
+    const month = monthKey(trade.date.getFullYear(), trade.date.getMonth() + 1);
+    const since = coveredFrom.get(trade.assetId);
+    if (since === undefined || month < since) coveredFrom.set(trade.assetId, month);
+    if (trade.type === 'adjustment') continue;
+    // Le commissioni sono denaro uscito dalle tasche per entrare (o non uscire) dal portafoglio:
+    // stessa convenzione di `computeInvestedCapital`.
+    const fees = trade.fees ?? 0;
+    const amount =
+      trade.type === 'buy'
+        ? trade.quantity * trade.priceEur + fees
+        : -(trade.quantity * trade.priceEur - fees);
+    const key = `${trade.assetId}|${month}`;
+    flows.set(key, (flows.get(key) ?? 0) + amount);
+  }
+
+  return { flows, coveredFrom };
+}
+
+/**
+ * Il flusso netto di un mese: quanto capitale e' entrato (positivo) o uscito (negativo) dalla base
+ * fra due snapshot consecutivi.
+ *
+ * Per ogni asset in base sceglie la fonte secondo la regola in testa al file: il registro se
+ * l'asset e' coperto in quel mese, le Delta-quantita' altrimenti.
+ *
+ * @param previous - Lo snapshot del mese precedente
+ * @param current - Lo snapshot del mese misurato
+ * @param excludedIds - Gli `assetId` fuori base (da `resolvePerformanceExclusions`)
+ * @param ledger - Il registro indicizzato da `indexLedger`; assente = solo Delta-quantita'
+ * @param flowOpaqueIds - Asset la cui quantita' assorbe anche il mercato (fondi pensione): niente
+ *   Delta-quantita' su di loro, o il loro rendimento verrebbe letto come versamento
+ * @returns Euro entrati nella base
+ */
+export function computeMonthlyPortfolioFlow(
+  previous: MonthlySnapshot,
+  current: MonthlySnapshot,
+  excludedIds: Set<string>,
+  ledger?: { flows: Map<string, number>; coveredFrom: Map<string, string> },
+  flowOpaqueIds: Set<string> = new Set()
+): number {
+  const before = positionsInBase(previous, excludedIds);
+  const after = positionsInBase(current, excludedIds);
+  const month = monthKey(current.year, current.month);
+
+  let flow = 0;
+  for (const assetId of new Set([...before.keys(), ...after.keys()])) {
+    const coveredFrom = ledger?.coveredFrom.get(assetId);
+    if (coveredFrom !== undefined && month >= coveredFrom) {
+      // Coperto dal registro: e' la fonte, anche quando non ha operazioni QUEL mese (nessuna
+      // operazione = nessun flusso, che e' un'informazione, non un buco da riempire).
+      flow += ledger!.flows.get(`${assetId}|${month}`) ?? 0;
+      continue;
+    }
+    if (flowOpaqueIds.has(assetId)) continue;
+    const from = before.get(assetId);
+    const to = after.get(assetId);
+    const deltaQuantity = (to?.quantity ?? 0) - (from?.quantity ?? 0);
+    if (deltaQuantity === 0) continue;
+    // Una posizione chiusa non ha prezzo nel mese corrente: si valorizza all'ultimo noto.
+    flow += deltaQuantity * (to?.price ?? from?.price ?? 0);
+  }
+  return flow;
+}
+
+/**
+ * I flussi mensili del portafoglio, nella forma che il resto della pipeline gia' consuma.
+ *
+ * **Una voce per ogni mese MISURABILE, zeri compresi.** Le coppie sono quelle di snapshot
+ * consecutivi — le stesse che `calculateTimeWeightedReturn` collega — e una coppia e' misurabile
+ * solo se entrambi i mesi hanno il `byAsset`. Un mese assente significa «non misurabile», e il
+ * chiamante deve ricadere sul Cashflow; un mese presente a zero significa «misurato, non si e'
+ * mosso niente». Confondere le due cose azzererebbe i flussi di chi non ha breakdown.
+ *
+ * Solo `netCashFlow` e' misurato: `income`/`expenses`/`dividendIncome` restano a zero perche' un
+ * acquisto non e' ne' uno stipendio ne' una spesa, e riempirli con i numeri del Cashflow
+ * mescolerebbe due perimetri diversi nello stesso oggetto.
+ *
+ * @param snapshots - Gli snapshot dell'account, in qualsiasi ordine (non vengono modificati)
+ * @param excludedAssetIds - Gli `assetId` fuori base
+ * @param trades - Il registro operazioni; assente o vuoto = tutto sulle Delta-quantita'
+ * @param flowOpaqueAssetIds - Asset la cui quantita' assorbe anche il mercato (fondi pensione)
+ * @returns Un `CashFlowData` per ogni mese misurabile, ordinato per data
+ */
+export function buildPortfolioCashFlows(
+  snapshots: MonthlySnapshot[],
+  excludedAssetIds: string[],
+  trades: AssetTransaction[] = [],
+  flowOpaqueAssetIds: string[] = []
+): CashFlowData[] {
+  const excludedIds = new Set(excludedAssetIds);
+  const opaqueIds = new Set(flowOpaqueAssetIds);
+  const ledger = trades.length > 0 ? indexLedger(trades) : undefined;
+  const ordered = [...snapshots].sort((a, b) =>
+    a.year !== b.year ? a.year - b.year : a.month - b.month
+  );
+
+  const flows: CashFlowData[] = [];
+  for (let i = 1; i < ordered.length; i += 1) {
+    const previous = ordered[i - 1];
+    const current = ordered[i];
+    if (!hasAssetBreakdown(previous) || !hasAssetBreakdown(current)) continue;
+    flows.push({
+      date: new Date(current.year, current.month - 1, 1),
+      income: 0,
+      expenses: 0,
+      dividendIncome: 0,
+      netCashFlow: computeMonthlyPortfolioFlow(previous, current, excludedIds, ledger, opaqueIds),
+    });
+  }
+  return flows;
+}

--- a/types/performance.ts
+++ b/types/performance.ts
@@ -77,6 +77,23 @@ export interface PerformanceMetrics {
   totalContributions: number; // Sum of positive net cash flows
   totalWithdrawals: number; // Sum of negative net cash flows
   netCashFlow: number; // Total contributions - withdrawals
+  /**
+   * Da dove vengono i flussi che neutralizzano il rendimento — i FLUSSI SEGUONO LA BASE.
+   *
+   * `portfolio`: variazioni di quantita' degli strumenti in base (`lib/utils/portfolioFlows.ts`).
+   *   E' la lettura giusta quando la liquidita' sta FUORI dalla base, perche' li' un acquisto e'
+   *   denaro che attraversa il confine — e il Cashflow non puo' vederlo, salta i trasferimenti.
+   * `cashflow`: entrate meno uscite del Cashflow, la lettura giusta quando la base e' tutto il
+   *   patrimonio e solo il denaro esterno lo cambia.
+   *
+   * `mixed`: entrambe, mese per mese. Un flusso di portafoglio e' misurabile solo dove esiste il
+   *   `byAsset` di due mesi consecutivi; dove non c'e' si ricade sul Cashflow, che e' sempre meglio
+   *   di zero. Uno storico con snapshot inseriti a mano finisce naturalmente qui.
+   *
+   * Cambia il significato di `netCashFlow`/`totalContributions`/`totalWithdrawals`, non quello di
+   * `totalIncome`/`totalExpenses`/`totalDividendIncome`, che vengono sempre dal Cashflow.
+   */
+  flowSource: 'portfolio' | 'cashflow' | 'mixed';
   totalIncome: number; // Sum of all income in period (NO dividendi)
   totalExpenses: number; // Sum of all expenses in period
   totalDividendIncome: number; // Sum of all dividend income (rendimento portafoglio)

--- a/types/performance.ts
+++ b/types/performance.ts
@@ -132,7 +132,9 @@ export interface PerformanceMetrics {
 export interface RollingPeriodPerformance {
   periodEndDate: Date;
   periodStartDate: Date;
-  cagr: number;
+  // `null` = finestra non misurabile, esattamente come per gli altri due. Un CAGR nullo disegnato
+  // come 0% direbbe «quell'anno non ha reso niente» al posto di «quell'anno non si puo' misurare».
+  cagr: number | null;
   sharpeRatio: number | null;
   volatility: number | null;
 }
@@ -149,7 +151,6 @@ export interface PerformanceData {
 
   // Rolling period trends
   rolling12M: RollingPeriodPerformance[];
-  rolling36M: RollingPeriodPerformance[];
 
   // Metadata
   lastUpdated: Date;
@@ -214,7 +215,6 @@ export interface FirestorePerformanceData {
   fiveYear: FirestorePerformanceMetrics;
   allTime: FirestorePerformanceMetrics;
   rolling12M: FirestoreRollingPeriodPerformance[];
-  rolling36M: FirestoreRollingPeriodPerformance[];
   lastUpdated: Timestamp;
   snapshotCount: number;
 }


### PR DESCRIPTION
## Il problema

`lib/utils/performanceBase.ts` permette all'utente di **escludere capitale** dalla base dei
Rendimenti — di default i fondi pensione e gli asset con `allocationRole: 'excluded'`, tipicamente
la casa in cui vive o i conti liquidi. La base misurata diventa così un sottoinsieme del patrimonio.

`getCashFlowsFromExpenses` (`lib/services/performanceService.ts`) produce i flussi che neutralizzano
il rendimento, e **salta i trasferimenti per costruzione**:

```ts
// Transfers are net-zero for portfolio metrics — skip before touching the map
if (expense.type === 'transfer') return;
```

È vero sul patrimonio totale. **Non è vero su una base ridotta**: se la liquidità sta fuori dalla
base, comprare uno strumento con i soldi di un conto è denaro che *entra* nel capitale misurato, e
quel trasferimento è esattamente ciò che la funzione non può vedere.

I due moduli misurano perimetri diversi. Il risultato è che ogni acquisto viene letto come
rendimento.

Il difetto era già noto e sottostimato — dal commento in testa a `performanceBase.ts`:

> `KNOWN LIMITATION: un versamento VOLONTARIO è un trasferimento dal portafoglio (cassa) verso il
> fondo escluso, quindi sulla base portfolio appare come un piccolo deflusso non neutralizzato.`

Non è un piccolo residuo quando è la liquidità a stare fuori: diventa il termine dominante.

## L'evidenza

Su un account reale con gli 11 conti liquidi marcati `excluded`, febbraio → agosto 2026:

| | valore |
|---|---|
| strumenti acquistati nel periodo | **35.208 €** |
| flussi effettivamente neutralizzati | **659 €** |
| TWR annualizzato mostrato | **35,1%** |
| TWR annualizzato corretto | **~17%** |

Febbraio 2026 da solo: la pagina leggeva **+13,14%**, il reale era **+2,87%**. La pipeline è stata
riprodotta fuori dall'app e i numeri della schermata escono identici, quindi la diagnosi è misurata,
non dedotta.

## La regola

**I flussi seguono la base.**

- La base è tutto il patrimonio (`exclusions` vuoto) → i flussi restano quelli del Cashflow. Solo il
  denaro che arriva dall'esterno cambia il capitale misurato: è esattamente la domanda che il
  Cashflow risponde. **Nessun cambiamento di comportamento.**
- La base è un sottoinsieme → i flussi si misurano su ciò che attraversa il confine, con il nuovo
  modulo `lib/utils/portfolioFlows.ts`.

Dentro il nuovo modulo, la fonte si sceglie **per asset**:

1. **Registro operazioni**, da dove quell'asset ha il suo primo movimento registrato. È la fonte
   migliore perché è datata all'*operazione*, mentre uno snapshot è datato alla *rilevazione*.
2. **Δquantità di `byAsset`** (`Σ (q₁ − q₀) × p₁`) prima di quella data, o per gli asset che nel
   registro non compaiono mai.

Nessuna delle due, da sola, regge:

- il **registro da solo** conosce solo ciò che è stato registrato. Su un account reale registrava
  l'acquisto di un portafoglio nuovo (30.065 €) senza la vendita del vecchio, avvenuta presso un
  altro intermediario: quel mese, da solo, valeva **−100%**;
- le **Δquantità da sole** sbagliano il mese al confine: 722 quote comprate il 20/08 stanno nel
  registro ad agosto e nello snapshot di fine mese a settembre.

Insieme, per asset, coprono entrambi i buchi.

La conseguenza che conta è sul futuro: **un utente che registra le sue operazioni ha ogni asset
coperto**, quindi la misura è interamente basata sul registro e le Δquantità non intervengono mai.
La rete serve allo storico, non lo zavorra.

## Chi vede un cambiamento

| profilo | prima | dopo |
|---|---|---|
| nessun asset escluso | Cashflow | **identico** |
| snapshot senza `byAsset` (inseriti a mano) | Cashflow | **identico** (fallback per mese) |
| esclude qualcosa, ha il `byAsset` | acquisti letti come rendimento | flussi misurati |
| esclude qualcosa, tiene il registro | come sopra | flussi dal registro, datati all'operazione |

Il fallback è **per mese**, non per periodo: un flusso di portafoglio è misurabile solo dove esiste
il `byAsset` di due mesi consecutivi, e dove non c'è si ricade sul Cashflow. Un mese *misurato* che
vale zero e un mese *non misurabile* sono fatti diversi e restano distinti — confonderli azzererebbe
i flussi di chi non ha breakdown, ed è la regressione che questa forma evita.

`PerformanceMetrics.flowSource` (`'portfolio' | 'cashflow' | 'mixed'`) dice quale fonte ha prodotto i
numeri, e la tessera Contributi lo riporta invece di stampare un capitale investito che nessuna
formula ha usato.

## Anche le finestre rolling (secondo commit)

La prima versione di questa PR applicava la regola ai **cinque periodi fissi** e non a
`calculateRollingPeriods`, che restava sul Cashflow. Le due tessere rolling del «Dettaglio»
misuravano quindi **il capitale della base con i flussi del patrimonio**: gli snapshot arrivavano
già proiettati da `toPerformanceBaseSnapshots`, i flussi no. Con esclusioni attive ogni finestra
sottraeva da un capitale ridotto i versamenti dell'intero patrimonio, e CAGR, TWR, volatilità e
Sharpe rolling divergevano dai numeri di periodo mostrati **sopra, nella stessa pagina**.

Era la stessa incoerenza che questa PR nasce per eliminare, sopravvissuta in metà del codice: una
base sono due metà — quale capitale, quali flussi — e applicarne una sola non risponde né alla
domanda sul portafoglio né a quella sul patrimonio.

La regola vive ora in **una funzione sola**, `resolveBaseAwareCashFlows`, condivisa da ogni finestra
di misura. Resta dinamica esattamente come prima: senza esclusioni `portfolioFlows` è `undefined` e
il Cashflow torna a essere la fonte giusta, quindi **su un account senza esclusioni non cambia un
decimale**.

Nella stessa passata, due cose che stavano lì accanto:

- **un CAGR rolling non misurabile è `null` invece di `0`.** Era `cagr || 0`, che schiacciava anche
  uno zero legittimo — una finestra finita dov'era partita è un rendimento vero, non un dato
  mancante. `sharpeRatio` e `volatility` sono `null` per lo stesso motivo da sempre: ora i tre campi
  dicono la stessa cosa allo stesso modo.
- **rimosso `rolling36M`**: calcolato per ogni caricamento, serializzato e scritto in cache, senza
  che nessuna superficie lo leggesse (verificato con una ricerca su `app/`, `components/`, `lib/` e
  `types/`). Sta nello stesso commit del resto ma tocca solo quattro righe — la chiamata, il campo
  nel risultato e le due nei serializzatori: se preferisci tenerlo, dimmelo e lo rimetto.

## Limiti dichiarati

- **Δquantità: prezzo di fine mese, non di operazione.** Un acquisto a metà mese è valorizzato alla
  chiusura: giusto in quantità, approssimato in euro. È la convenzione «flusso a fine periodo», la
  stessa che il resto della pipeline già assume. Non riguarda il ramo registro.
- **Δquantità: non ogni variazione di quantità è un'operazione.** Split, fusioni, conferimenti in
  natura e dividendi reinvestiti in quote muovono le quantità senza denaro.
- **Registro: un'operazione non registrata sparisce.** Per un asset coperto le Δquantità non
  intervengono più. Vedi il follow-up.
- **Asset opachi al flusso.** Un fondo pensione tiene il valore in `quantity` con prezzo 1
  (`assertFundValueLivesInQuantity`), quindi la sua quantità cresce sia per i versamenti sia per il
  mercato. Su questi le Δquantità non si applicano — altrimenti il rendimento del fondo sparirebbe —
  e i loro versamenti restano non neutralizzati, cioè la limitazione odierna. Un conto corrente
  **non** è opaco: lì la quantità è il saldo.
- **Gli interessi di un conto corrente** dentro la base vengono letti come contributo, non come
  rendimento.

## Correzione indipendente: basi non positive

Cinque divisioni controllavano `=== 0` ma non il negativo (`calculateROI`, TWR, IRR, volatilità,
rendimenti mensili) più `buildTwrIndex` in `drawdownSeries.ts`. Un capitale iniziale negativo — debito
netto, o un mese interamente liquidato — non faceva fallire il calcolo: **ribaltava il segno in
silenzio**, e nella catena del TWR un mese così vale −100% e azzera tutto il periodo. Ora sono tutte
`<= 0`, cioè «nessun rendimento percentuale da misurare».

Non ha nulla a che vedere con il resto della PR e può essere estratta in un commit a sé.

## Cache

`CACHE_MATH_VERSION` sale a `v7` (`v6` col primo commit, `v7` con quello sulle rolling): ogni
numero in cache è stato calcolato con la matematica precedente. `buildCacheKey` include ora anche una firma del registro (conteggio + operazione più
recente) — senza, registrare una vendita non invaliderebbe la cache e la pagina resterebbe sui
valori vecchi fino alla scadenza delle 6 ore.

Il registro viene letto prima del controllo di cache, quindi è **una query indicizzata in più per
caricamento**, che si sovrappone a quella che la pagina fa già con React Query. È il prezzo di non
servire numeri stantii dopo un'operazione. Una lettura fallita non degrada in silenzio: logga e
ricade sulle sole Δquantità.

## Test

`__tests__/portfolioFlows.test.ts`, 22 casi: variazione di prezzo che non è un flusso, acquisto,
vendita, posizione chiusa, asset fuori base, mesi misurabili e non, registro preferito per asset,
commissioni, `adjustment`, asset opachi, conto corrente non opaco, mese misurato a zero.
Più le regressioni sulla base non positiva in `performanceService.test.ts` e `drawdownSeries.test.ts`.

`__tests__/performanceRolling.test.ts` copre il secondo commit: una finestra rolling con esclusioni
che prende i flussi misurati invece di quelli del Cashflow, il ripiego mese per mese dove il
`byAsset` manca, e il CAGR non misurabile che resta `null`.

Suite completa **su questo branch**, cioè `develop` + i due commit: **145 file, 3256 test verdi**
sotto `TZ=Europe/Rome`, `tsc --noEmit` pulito.

## Follow-up (non in questa PR)

**Riconciliazione fra registro e Δquantità.** È la guardia che rende difendibile il «registro
prima»: per un asset coperto, un'operazione che l'utente dimentica di registrare sparisce dal flusso
e gonfia il rendimento, senza che niente lo segnali. Le due fonti sono calcolabili entrambe per ogni
mese; basta confrontarle e segnalare le divergenze oltre una soglia — nella tessera Contributi o
nel Dettaglio.

Ho provato a scriverla prima di proporla, e **il modo ovvio non funziona**: confrontare le due fonti
*in euro, mese per mese* produce solo rumore. Su 23 mesi di un account reale dà 9 falsi allarmi, il
più grande da 18.388 € in un mese solo, generati tutti dallo sfasamento fra data d'operazione
(registro) e data di rilevazione (snapshot). In **quantità sul cumulato** invece torna esatta a
0.0000 su tutti e 15 gli asset coperti.

La aprirò come issue separata con il disegno per esteso, se ti interessa la direzione.

