### PR TITLE
Previdenza: un TWR che i versamenti hanno prodotto non è una misura

### DIFF
--- a/__tests__/pensionNarrative.test.ts
+++ b/__tests__/pensionNarrative.test.ts
@@ -49,6 +49,7 @@ const RETURN: PensionReturnResult = {
   annualizedTwr: 10.75,
   personalReturn: 8.12,
   isCoverageSuspicious: false,
+  isCoverageContradictory: false,
   hasNoMovement: false,
 };
 

--- a/__tests__/pensionReturn.test.ts
+++ b/__tests__/pensionReturn.test.ts
@@ -497,3 +497,106 @@ describe('isPensionReturnMeasurable', () => {
     expect(isPensionReturnMeasurable(result!)).toBe(false);
   });
 });
+
+describe('computePensionReturn — isCoverageContradictory', () => {
+  const series = (values: [number, number, number][]) =>
+    values.map(([year, month, value]) => ({ year, month, value }));
+
+  /**
+   * Il caso del 2026-08-31, ridotto ai suoi numeri e riscritto su importi tondi: cinque mesi di
+   * versamenti registrati tutti lo stesso giorno, quindi attribuiti da `valueEffectMonth` a un
+   * mese solo. La finestra legge +50%, +33% e +25% di "mercato" (che erano versamenti) e poi
+   * sottrae 2.250 € da un mese che ne vale 2.270: TWR −97,33%, stampato come misura finché la
+   * guardia guardava solo verso l'alto.
+   */
+  const backfilledAllInAugust = [
+    contribution(2026, 4, 400, 'tfr', new Date(2026, 7, 28)),
+    contribution(2026, 4, 350, 'employer', new Date(2026, 7, 28)),
+    contribution(2026, 5, 200, 'tfr', new Date(2026, 7, 28)),
+    contribution(2026, 5, 175, 'employer', new Date(2026, 7, 28)),
+    contribution(2026, 6, 200, 'tfr', new Date(2026, 7, 28)),
+    contribution(2026, 6, 175, 'employer', new Date(2026, 7, 28)),
+    contribution(2026, 7, 200, 'tfr', new Date(2026, 7, 31)),
+    contribution(2026, 7, 175, 'employer', new Date(2026, 7, 28)),
+    contribution(2026, 8, 200, 'tfr', new Date(2026, 7, 31)),
+    contribution(2026, 8, 175, 'employer', new Date(2026, 7, 31)),
+  ];
+
+  const backfilledWindow = series([
+    [2026, 4, 750],
+    [2026, 5, 1125],
+    [2026, 6, 1500],
+    [2026, 7, 1875],
+    [2026, 8, 2270],
+  ]);
+
+  it('non spaccia per misura un TWR che i versamenti hanno prodotto', () => {
+    const result = computePensionReturn(backfilledWindow, backfilledAllInAugust, '2026-04')!;
+
+    expect(result.twr).toBeCloseTo(-97.33, 1);
+    expect(result.isCoverageContradictory).toBe(true);
+    expect(isPensionReturnMeasurable(result)).toBe(false);
+  });
+
+  it('normalizza a null l’annualizzato che uscirebbe NaN da un indice negativo', () => {
+    // Un mese in più e lo snapshot di agosto congelato sotto i versamenti che gli sono attribuiti:
+    // l'indice diventa negativo e `Math.pow(negativo, 12/5)` è NaN. Un NaN a valle passa ogni
+    // confronto senza far scattare nulla (`NaN > 20` è false) e finisce a schermo come «NaN%».
+    const result = computePensionReturn(
+      series([
+        [2026, 4, 750],
+        [2026, 5, 1125],
+        [2026, 6, 1500],
+        [2026, 7, 1875],
+        [2026, 8, 1860],
+        [2026, 9, 2300],
+      ]),
+      backfilledAllInAugust,
+      '2026-04'
+    )!;
+
+    expect(result.twr).toBeLessThan(-100);
+    expect(result.annualizedTwr).toBeNull();
+    expect(Number.isNaN(result.annualizedTwr as number)).toBe(false);
+    expect(result.isCoverageContradictory).toBe(true);
+    expect(isPensionReturnMeasurable(result)).toBe(false);
+  });
+
+  it('con la finestra aperta ad agosto la stessa storia torna misurabile', () => {
+    // I dieci versamenti hanno mese-effetto 2026-08 = `firstKey`, quindi escono come "già dentro
+    // il valore di apertura" — ed è vero. È il rimedio senza modifiche al codice.
+    const result = computePensionReturn(
+      series([
+        [2026, 8, 2270],
+        [2026, 9, 2670],
+      ]),
+      [...backfilledAllInAugust, contribution(2026, 9, 375, 'tfr', new Date(2026, 8, 30))],
+      '2026-08'
+    )!;
+
+    expect(result.contributions.total).toBeCloseTo(375, 2);
+    expect(result.twr).toBeCloseTo(1.1, 1);
+    expect(result.isCoverageContradictory).toBe(false);
+    expect(isPensionReturnMeasurable(result)).toBe(true);
+  });
+
+  it('NON si mangia un ribasso di mercato vero — la guardia sta all’impossibile, non all’implausibile', () => {
+    // −25% in un anno è il 2022 di un comparto azionario: sgradevole, non contraddittorio.
+    const result = computePensionReturn(
+      series([
+        [2026, 1, 10_000],
+        [2026, 2, 9_400],
+        [2026, 3, 8_900],
+        [2026, 4, 8_200],
+        [2026, 5, 7_500],
+      ]),
+      [],
+      '2026-01'
+    )!;
+
+    expect(result.twr).toBeCloseTo(-25, 0);
+    expect(result.isCoverageContradictory).toBe(false);
+    expect(result.isCoverageSuspicious).toBe(false);
+    expect(isPensionReturnMeasurable(result)).toBe(true);
+  });
+});

--- a/lib/utils/pensionNarrative.ts
+++ b/lib/utils/pensionNarrative.ts
@@ -105,6 +105,8 @@ function marketClause(block: PensionMemberBlock): Narrative {
       return [prose(`da ${start} il mercato ha reso `), signedPct(block.return!.twr), prose(' (TWR)')];
     case 'suspicious':
       return [prose('il rendimento non è misurabile perché mancano versamenti registrati')];
+    case 'contradictory':
+      return [prose('il rendimento non è misurabile perché risultano più versamenti della crescita')];
     case 'idle':
       return [prose(`da ${start} il valore non si è ancora mosso`)];
     case 'no-contributions':
@@ -278,6 +280,18 @@ function rendimentoClause(block: PensionMemberBlock, named: boolean): Narrative 
         amount(r.contributions.total),
         prose(' di versamenti: la differenza verrebbe letta come rendimento di mercato, e non lo è. Registra i versamenti mancanti'),
         prose(block.hasConfiguredStart ? '.' : ', oppure indica da quale mese il calcolo è affidabile nelle Impostazioni.'),
+      ];
+      break;
+    }
+    case 'contradictory': {
+      const r = result!;
+      body = [
+        prose(`${many ? 'i fondi sono cresciuti' : 'il fondo è cresciuto'} di `),
+        amount(r.valueGrowth),
+        prose(' ma risultano registrati '),
+        amount(r.contributions.total),
+        prose(' di versamenti, più della crescita stessa: o alcuni erano già inclusi nel valore che hai inserito a mano, o sono stati contati due volte. Non è un rendimento negativo, è un dato da sistemare'),
+        prose(block.hasConfiguredStart ? '.' : ': indica da quale mese il calcolo è affidabile nelle Impostazioni.'),
       ];
       break;
     }

--- a/lib/utils/pensionReturn.ts
+++ b/lib/utils/pensionReturn.ts
@@ -30,6 +30,17 @@
  * finestra è configurata ma i versamenti al suo interno mancano: un rendimento annualizzato oltre
  * `SUSPICIOUS_ANNUAL_RETURN` non è un fondo pensione brillante, sono versamenti non registrati.
  *
+ * E DALL'ALTRO LATO — `isCoverageContradictory`. La copertura si rompe anche al contrario:
+ * versamenti registrati PIÙ della crescita che dovrebbero spiegare. Succede quando il valore del
+ * fondo conteneva già quei soldi al momento della registrazione (uno storico inserito a posteriori,
+ * mentre «Valore attuale» veniva tenuto aggiornato a mano dall'estratto conto); la correzione
+ * manuale del NAV che ne segue è indistinguibile, da qui, da un crollo di mercato. Caso reale:
+ * cinque mesi di versamenti attribuiti a un mese solo hanno prodotto un TWR di −97 %, stampato
+ * come misura perché la guardia guardava solo verso l'alto. Un fondo non a leva non può perdere più del 100 %,
+ * nessun mese può chiudere sotto zero, e un valore cresciuto non convive con un TWR quasi azzerato:
+ * dove l'aritmetica esce dal reale, il numero non è una misura. Le due cause sono opposte e vogliono
+ * parole diverse, quindi due flag distinti.
+ *
  * Zero import Firebase: funzione pura dei suoi input (invariante #4).
  */
 
@@ -43,6 +54,29 @@ import { hasAssetBreakdown } from '@/lib/utils/snapshotAssetBreakdown';
  * medie a una cifra; il 20% è largo apposta, per segnalare solo i casi grossolani.
  */
 const SUSPICIOUS_ANNUAL_RETURN = 20;
+
+/**
+ * Perdita cumulata oltre la quale il calcolo ha lasciato il reale: senza leva un fondo non può
+ * valere meno di zero, quindi un TWR sotto il −100 % descrive i dati, non il mercato.
+ *
+ * Volutamente all'estremo dell'impossibile e non a una soglia "implausibile": il 2022 ha fatto
+ * −20 % a comparti azionari veri, e una guardia che si mangia i ribassi legittimi è peggio del
+ * problema che risolve. Qui passa solo ciò che è aritmeticamente escluso.
+ */
+const IMPOSSIBLE_CUMULATIVE_LOSS = -100;
+
+/**
+ * TWR sotto il quale una finestra il cui valore è CRESCIUTO si contraddice da sola.
+ *
+ * Il TWR è neutro ai flussi: versare non lo muove. Quindi un fondo che nella finestra è cresciuto
+ * in valore e insieme segna −97 % sta dicendo due cose incompatibili — a meno che i versamenti
+ * siano stati attribuiti al mese sbagliato, che è esattamente il caso da intercettare.
+ *
+ * La soglia sta oltre qualunque ribasso reale: il peggior drawdown di un comparto azionario è
+ * dell'ordine del −40/−55 %, e i versamenti non lo peggiorano. Sotto −75 % con il valore in
+ * crescita non c'è mercato che regga la spiegazione.
+ */
+const CONTRADICTORY_LOSS_WHILE_GROWING = -75;
 
 /** Sotto questa soglia annualizzare amplifica il rumore invece di informare. */
 const MIN_MONTHS_TO_ANNUALIZE = 3;
@@ -84,7 +118,13 @@ export interface PensionReturnResult {
   marketGain: number;
   /** Rendimento cumulato della finestra, in %. */
   twr: number;
-  /** TWR annualizzato; `null` sotto i 3 mesi di copertura. */
+  /**
+   * TWR annualizzato; `null` sotto i 3 mesi di copertura — e `null`, non `NaN`, anche quando
+   * l'indice della finestra è negativo: `Math.pow(negativo, 12/5)` non è definito, e un `NaN`
+   * che scivola a valle supera ogni confronto (`NaN > 20` è `false`) e arriva a schermo come
+   * «NaN%». Il caso è reale, non teorico: bastava un mese in cui i versamenti attribuiti
+   * superano il valore del fondo.
+   */
   annualizedTwr: number | null;
   /**
    * `(guadagno di mercato + contributo datoriale) / (valore iniziale + volontario + TFR)`, in %.
@@ -93,6 +133,20 @@ export interface PensionReturnResult {
   personalReturn: number | null;
   /** Il rendimento è troppo alto per essere vero: mancano versamenti nella finestra. */
   isCoverageSuspicious: boolean;
+  /**
+   * La causa opposta di `isCoverageSuspicious`: i versamenti registrati spiegano PIÙ della
+   * crescita che c'è stata, e il calcolo è finito fuori dal reale. Vero in tre casi:
+   *   - un singolo mese chiude a valore non positivo tolti i suoi versamenti — a quel mese ne sono
+   *     attribuiti più di quanti il fondo intero ne valga;
+   *   - la finestra perde più del 100 % (senza leva non si può perdere più di tutto);
+   *   - il valore è CRESCIUTO ma il TWR segna una perdita oltre ogni ribasso reale: il TWR è neutro
+   *     ai flussi, quindi le due cose insieme non stanno in piedi.
+   *
+   * Non è un rendimento pessimo: è un versamento contato due volte, o già dentro il valore che
+   * l'utente ha inserito a mano. Tenuto separato perché la frase da mostrare è un'altra —
+   * «registra i versamenti mancanti» sarebbe il consiglio esattamente sbagliato.
+   */
+  isCoverageContradictory: boolean;
   /**
    * La finestra è aperta ma non è ancora successo nulla dentro: né il valore si è mosso, né sono
    * stati registrati versamenti. Il `twr` vale allora 0 per ASSENZA di dati, non perché il fondo
@@ -105,8 +159,10 @@ export interface PensionReturnResult {
 /**
  * Il rendimento di questa finestra è una MISURA, o solo un numero che il calcolo ha prodotto?
  *
- * I due stati che dicono di no — `isCoverageSuspicious` e `hasNoMovement` — hanno cause opposte ma
- * la stessa conseguenza sullo schermo: la percentuale va sostituita da una spiegazione, e con essa
+ * I tre stati che dicono di no — `isCoverageSuspicious`, `isCoverageContradictory` e
+ * `hasNoMovement` — hanno cause diverse (versamenti che mancano, versamenti contati due volte,
+ * niente di misurabile) ma la stessa conseguenza sullo schermo: la percentuale va sostituita da
+ * una spiegazione, e con essa
  * TUTTA la scomposizione in euro che la spiegherebbe. «Guadagno di mercato» stampato sotto un avviso
  * che dice «quella differenza non è rendimento di mercato» contraddice l'avviso a quaranta pixel di
  * distanza — ed è il numero, non il testo, che l'occhio legge per primo.
@@ -116,7 +172,7 @@ export interface PensionReturnResult {
  * espressioni separate sono divergite (la card guardava entrambi i flag, il blocco solo uno).
  */
 export function isPensionReturnMeasurable(result: PensionReturnResult): boolean {
-  return !result.isCoverageSuspicious && !result.hasNoMovement;
+  return !result.isCoverageSuspicious && !result.isCoverageContradictory && !result.hasNoMovement;
 }
 
 /** Chiave mensile 'YYYY-MM'. */
@@ -276,12 +332,19 @@ export function computePensionReturn(
   }
 
   let index = 1;
+  // Un mese che, tolti i suoi versamenti, non vale più niente non è un mese di rendimento: è un
+  // mese a cui ne sono stati attribuiti più di quanti il fondo intero ne valga. L'indice da lì in
+  // poi è aritmetica su un dato rotto — si continua a calcolarlo per non perdere `twr`, ma il
+  // flag toglie al risultato lo statuto di misura.
+  let hasNonPositiveMonth = false;
   for (let i = 1; i < windowPoints.length; i++) {
     const startValue = windowPoints[i - 1].value;
     if (startValue === 0) continue;
     const key = monthKey(windowPoints[i].year, windowPoints[i].month);
     const paidIn = sumByNature(contributionsByMonth.get(key) ?? []).total;
-    index *= (windowPoints[i].value - paidIn) / startValue;
+    const netValue = windowPoints[i].value - paidIn;
+    if (netValue <= 0) hasNonPositiveMonth = true;
+    index *= netValue / startValue;
   }
 
   const startValue = windowPoints[0].value;
@@ -290,10 +353,14 @@ export function computePensionReturn(
   const monthsCovered = windowPoints.length - 1;
 
   const twr = (index - 1) * 100;
-  const annualizedTwr =
+  // `Math.pow` di un indice negativo a esponente frazionario è NaN, e un NaN a valle passa ogni
+  // confronto senza far scattare nulla: si normalizza a null, che è già il "non calcolabile" del
+  // campo.
+  const rawAnnualized =
     monthsCovered >= MIN_MONTHS_TO_ANNUALIZE
       ? (Math.pow(index, 12 / monthsCovered) - 1) * 100
       : null;
+  const annualizedTwr = rawAnnualized !== null && Number.isFinite(rawAnnualized) ? rawAnnualized : null;
 
   const marketGain = endValue - startValue - contributionsInWindow.total;
   const ownCapital = startValue + contributionsInWindow.voluntary + contributionsInWindow.tfr;
@@ -313,6 +380,10 @@ export function computePensionReturn(
       ownCapital > 0 ? ((marketGain + contributionsInWindow.employer) / ownCapital) * 100 : null,
     isCoverageSuspicious:
       annualizedTwr !== null && annualizedTwr > SUSPICIOUS_ANNUAL_RETURN,
+    isCoverageContradictory:
+      hasNonPositiveMonth ||
+      twr < IMPOSSIBLE_CUMULATIVE_LOSS ||
+      (endValue - startValue > 0 && twr < CONTRADICTORY_LOSS_WHILE_GROWING),
     hasNoMovement:
       Math.abs(endValue - startValue) < MOVEMENT_EPSILON_EUR &&
       contributionsInWindow.total < MOVEMENT_EPSILON_EUR,

--- a/lib/utils/pensionSummary.ts
+++ b/lib/utils/pensionSummary.ts
@@ -190,6 +190,12 @@ export type PensionReturnState =
   | 'measured'
   /** `isCoverageSuspicious`: the growth is too high for the contributions recorded. */
   | 'suspicious'
+  /**
+   * `isCoverageContradictory`: the mirror image — MORE contributions recorded than the growth
+   * they should explain, so the arithmetic left the real. A contribution counted twice, or one
+   * already inside a hand-entered value, never a bad market.
+   */
+  | 'contradictory'
   /** `hasNoMovement`: the window is open but nothing happened inside it. */
   | 'idle'
   /** No contribution recorded and no configured start: the window cannot open. */
@@ -250,7 +256,11 @@ export interface PensionMemberBlock {
 function resolveReturnState(result: PensionReturnResult | null, startMonth: string | null): PensionReturnState {
   if (result) {
     if (isPensionReturnMeasurable(result)) return 'measured';
-    return result.isCoverageSuspicious ? 'suspicious' : 'idle';
+    // Order matters: a contradictory window can also read as idle-ish once the flags overlap, and
+    // the contradiction is the more specific — and the more actionable — of the two.
+    if (result.isCoverageSuspicious) return 'suspicious';
+    if (result.isCoverageContradictory) return 'contradictory';
+    return 'idle';
   }
   return startMonth === null ? 'no-contributions' : 'one-point';
 }


### PR DESCRIPTION
## Il problema

`computePensionReturn` (`lib/utils/pensionReturn.ts`) sa già che un rendimento può non essere una
misura, ma guarda **da un lato solo**. `isCoverageSuspicious` intercetta il caso in cui il fondo
cresce più di quanto i versamenti registrati spieghino — crescita troppo bella per essere vera,
quindi *mancano* dei versamenti.

La rottura opposta passava invece per misura: **versamenti registrati per più della crescita che
dovrebbero spiegare**.

Capita a chi inserisce lo storico dei versamenti *a posteriori* mentre teneva «Valore attuale»
aggiornato a mano dall'estratto conto. Quei soldi erano già dentro il valore, e `valueEffectMonth`
attribuisce ogni versamento al mese in cui è stato **registrato**: dieci versamenti inseriti nello
stesso giorno finiscono tutti su un mese solo.

Il TWR mensile è `(valore − versamenti del mese) / valore precedente`. Se a un mese sono attribuiti
più versamenti di quanti il fondo intero ne valga, quel fattore collassa — o diventa negativo — e la
pagina Previdenza stampa un rendimento vicino a **−100 %** come se fosse mercato, con sotto tutta la
scomposizione in euro che dovrebbe spiegarlo.

Un mese più in là il difetto peggiora in silenzio: l'indice della finestra diventa **negativo**,
`Math.pow(negativo, 12/5)` è `NaN`, e un `NaN` supera ogni confronto a valle senza far scattare
niente (`NaN > 20` è `false`) fino ad arrivare a schermo come **«NaN%»**.

## La correzione

- **`isCoverageContradictory`**, nuovo flag su `PensionReturnResult`. Tenuto **separato** da
  `isCoverageSuspicious` e non fuso in un unico «copertura rotta»: le due cause sono opposte e
  vogliono frasi opposte — «registra i versamenti mancanti» sarebbe qui il consiglio esattamente
  sbagliato. Il messaggio giusto è che un versamento è stato contato due volte, o era già dentro il
  valore inserito a mano.
- **`annualizedTwr` normalizzato a `null`** quando non è finito. `null` è già il «non calcolabile»
  di quel campo (lo usa la soglia dei 3 mesi), quindi non ci sono nuovi stati da gestire a valle.
- **`isPensionReturnMeasurable`** include il nuovo flag: cade la percentuale *e* con essa tutta la
  scomposizione in euro, esattamente come per gli altri due stati non misurabili. «Guadagno di
  mercato» stampato sotto un avviso che dice «quella differenza non è rendimento di mercato» si
  contraddice a quaranta pixel di distanza.
- **`pensionSummary`** aggiunge lo stato `contradictory` alla union `PensionReturnState` e
  **`pensionNarrative`** le sue due frasi (clausola di mercato e blocco «Rendimento»), che dicono
  quanto è cresciuto il fondo, quanti versamenti risultano, e che non è un rendimento negativo ma un
  dato da sistemare.

## Le soglie stanno all'impossibile, non all'implausibile

Una guardia che si mangia i ribassi legittimi è peggio del problema che risolve: il 2022 ha fatto
−20 % a comparti azionari veri. Qui passa solo ciò che è **aritmeticamente escluso**:

| condizione | perché |
|---|---|
| un mese chiude a `valore − versamenti <= 0` | a quel mese sono attribuiti più versamenti di quanti il fondo intero ne valga |
| TWR cumulato `< −100 %` | senza leva un fondo non può valere meno di zero |
| TWR `< −75 %` **con il valore in crescita** | un fondo che cresce e "rende" −75 % descrive i dati, non il mercato |

Un test fissa il confine dall'altro lato: **−25 % in un anno resta una misura**, e continua a
comparire come tale.

## Profilo di rischio

**Nessun cambiamento** per chi ha i versamenti registrati in modo coerente con il valore: i tre
predicati sono falsi e il risultato è identico a prima. Cambia solo dove oggi la pagina mostra un
numero che nessuna misurazione ha davvero prodotto.

## Verifica

`tsc` pulito, **146 file / 3262 test verdi** sotto `TZ=Europe/Rome` su questa base. Quattro test
nuovi su `computePensionReturn`, uno su `pensionNarrative`: la finestra contraddittoria, l'indice
negativo che darebbe `NaN`, la stessa storia che torna misurabile riaprendo la finestra al mese in
cui i versamenti sono stati registrati (il rimedio lato utente, senza modifiche al codice), e il
ribasso di mercato vero che **non** deve scattare.
