### PR TITLE
Patrimonio: il G/P confronta due valute diverse su una posizione estera

### DIFF
--- a/__tests__/assetTransactionAverageCostEurBackfill.test.ts
+++ b/__tests__/assetTransactionAverageCostEurBackfill.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Integration test for backfillAverageCostEur (assetTransactionUseCase.ts) — the one-shot,
+ * per-user projection that fixes G/P for foreign-currency positions predating averageCostEur (see
+ * lib/utils/patrimonioSummary.ts → costBasisPerUnitEur). Runs the REAL use-case function against a
+ * minimal fake Admin SDK (get/update only — no transaction needed here), with getUserAssetsAdmin
+ * mocked to sidestep Firestore Timestamp plumbing unrelated to what this function does.
+ */
+
+const mocks = vi.hoisted(() => ({
+  assetsStore: new Map<string, Record<string, unknown>>(),
+  tradesStore: new Map<string, Record<string, unknown>>(),
+  metaStore: new Map<string, Record<string, unknown>>(),
+  invalidate: vi.fn().mockResolvedValue(undefined),
+  ledgerAssets: [] as { id: string; type: string; quantity: number }[],
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/lib/services/dashboardOverviewInvalidation.server', () => ({
+  invalidateDashboardOverviewSummaryServer: (...args: unknown[]) => mocks.invalidate(...args),
+}));
+
+// Sidesteps the real query + Timestamp.toDate() plumbing: the backfill only needs id/type/quantity
+// from this call, all of which the test fixtures below control directly.
+vi.mock('@/lib/server/assetAdminRepository', () => ({
+  getUserAssetsAdmin: vi.fn(async () => mocks.ledgerAssets),
+}));
+
+vi.mock('@/lib/firebase/admin', () => {
+  const { assetsStore, tradesStore, metaStore } = mocks;
+  const storeFor = (collection: string) =>
+    collection === 'assets' ? assetsStore : collection === 'assetTransactionsMeta' ? metaStore : tradesStore;
+
+  const makeDocRef = (collection: string, id: string) => ({
+    id,
+    get: async () => {
+      const data = storeFor(collection).get(id);
+      return { exists: data !== undefined, id, data: () => data };
+    },
+    update: async (data: Record<string, unknown>) => {
+      const store = storeFor(collection);
+      const existing = store.get(id) ?? {};
+      store.set(id, { ...existing, ...data });
+    },
+  });
+
+  const adminDb = {
+    collection: (name: string) => ({
+      doc: (id: string) => makeDocRef(name, id),
+      where: (field: string, _op: string, value: unknown) => {
+        const filters = [{ field, value }];
+        const query = {
+          where: (f2: string, _op2: string, v2: unknown) => {
+            filters.push({ field: f2, value: v2 });
+            return query;
+          },
+          get: async () => {
+            const docs: { id: string; data: () => Record<string, unknown> }[] = [];
+            for (const [id, value] of storeFor(name)) {
+              if (filters.every((f) => value[f.field] === f.value)) {
+                docs.push({ id, data: () => value });
+              }
+            }
+            return { docs, empty: docs.length === 0 };
+          },
+        };
+        return query;
+      },
+    }),
+  };
+
+  return { adminDb };
+});
+
+import { backfillAverageCostEur } from '@/lib/server/assetTransactionUseCase';
+
+const OWNER = 'owner-1';
+
+function seedMeta(overrides: Record<string, unknown> = {}) {
+  mocks.metaStore.set(OWNER, {
+    userId: OWNER,
+    migratedAt: new Date(2026, 0, 1),
+    baselineDate: new Date(2026, 0, 1),
+    migratedAssetCount: 1,
+    createdAt: new Date(2026, 0, 1),
+    updatedAt: new Date(2026, 0, 1),
+    ...overrides,
+  });
+}
+
+function seedTrade(assetId: string, id: string, data: Record<string, unknown>) {
+  mocks.tradesStore.set(id, {
+    userId: OWNER,
+    assetId,
+    isBaseline: false,
+    fees: undefined,
+    linkedCashAssetId: undefined,
+    note: undefined,
+    createdAt: data.date,
+    updatedAt: data.date,
+    ...data,
+  });
+}
+
+describe('backfillAverageCostEur', () => {
+  beforeEach(() => {
+    mocks.assetsStore.clear();
+    mocks.tradesStore.clear();
+    mocks.metaStore.clear();
+    mocks.invalidate.mockClear();
+    mocks.ledgerAssets = [];
+  });
+
+  it('is a no-op before migration has run (no meta doc)', async () => {
+    const result = await backfillAverageCostEur(OWNER);
+    expect(result).toEqual({ alreadyBackfilled: true });
+    expect(mocks.metaStore.has(OWNER)).toBe(false); // never creates a partial meta doc
+  });
+
+  it('is a no-op once already backfilled', async () => {
+    seedMeta({ averageCostEurBackfilledAt: new Date(2026, 0, 2) });
+    const result = await backfillAverageCostEur(OWNER);
+    expect(result).toEqual({ alreadyBackfilled: true });
+  });
+
+  it('projects a EUR-side PMC distinct from the native PMC for a foreign-currency asset', async () => {
+    seedMeta();
+    mocks.assetsStore.set('asset-usd', { userId: OWNER, type: 'etf', currency: 'USD', quantity: 10 });
+    mocks.ledgerAssets = [{ id: 'asset-usd', type: 'etf', quantity: 10 }];
+    // 10 units at 100 USD/quota, but the trade-date rate made it 90 EUR/quota.
+    seedTrade('asset-usd', 't1', { type: 'buy', date: new Date(2026, 0, 5), quantity: 10, pricePerUnit: 100, priceEur: 90 });
+
+    const result = await backfillAverageCostEur(OWNER);
+
+    expect(result).toEqual({ recomputedAssetCount: 1 });
+    const asset = mocks.assetsStore.get('asset-usd')!;
+    expect(asset.quantity).toBe(10);
+    expect(asset.averageCost).toBe(100); // native PMC, unchanged
+    expect(asset.averageCostEur).toBe(90); // the field this backfill exists to add
+    expect(mocks.metaStore.get(OWNER)!.averageCostEurBackfilledAt).toBeInstanceOf(Date);
+    expect(mocks.invalidate).toHaveBeenCalledWith(OWNER, 'average_cost_eur_backfilled');
+  });
+
+  it('skips a ledger asset with no trades and never touches holdingStartDate', async () => {
+    seedMeta();
+    mocks.assetsStore.set('asset-empty', {
+      userId: OWNER,
+      type: 'etf',
+      currency: 'EUR',
+      quantity: 5,
+      holdingStartDate: new Date(2020, 0, 1),
+    });
+    mocks.ledgerAssets = [{ id: 'asset-empty', type: 'etf', quantity: 5 }];
+    // No matching trade docs seeded — the by-asset query comes back empty.
+
+    const result = await backfillAverageCostEur(OWNER);
+
+    expect(result).toEqual({ recomputedAssetCount: 0 });
+    const asset = mocks.assetsStore.get('asset-empty')!;
+    expect(asset.averageCostEur).toBeUndefined();
+    expect(asset.holdingStartDate).toEqual(new Date(2020, 0, 1));
+    expect(mocks.invalidate).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent: re-running after a successful backfill is a no-op', async () => {
+    seedMeta();
+    mocks.assetsStore.set('asset-usd', { userId: OWNER, type: 'etf', currency: 'USD', quantity: 10 });
+    mocks.ledgerAssets = [{ id: 'asset-usd', type: 'etf', quantity: 10 }];
+    seedTrade('asset-usd', 't1', { type: 'buy', date: new Date(2026, 0, 5), quantity: 10, pricePerUnit: 100, priceEur: 90 });
+
+    await backfillAverageCostEur(OWNER);
+    mocks.invalidate.mockClear();
+    const second = await backfillAverageCostEur(OWNER);
+
+    expect(second).toEqual({ alreadyBackfilled: true });
+    expect(mocks.invalidate).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/assetTransactionUtils.test.ts
+++ b/__tests__/assetTransactionUtils.test.ts
@@ -278,8 +278,21 @@ describe('replayTransactions — position replay and PMC', () => {
     expect(derived).toEqual({
       quantity: 10,
       averageCost: state.averageCost,
+      averageCostEur: state.averageCostEur,
       holdingStartDate: state.holdingStartDate,
     });
+  });
+
+  it('projects a distinct averageCostEur when the trade FX differs from the native price', () => {
+    // Native price 100 USD/quota, but the trade-date FX made it 90 EUR/quota — the two PMCs must
+    // diverge, otherwise the projection is silently collapsing the EUR side back onto the native one.
+    const state = replayTransactions([
+      tx({ type: 'buy', date: day(0), quantity: 10, pricePerUnit: 100, priceEur: 90 }),
+    ]);
+    const derived = buildDerivedAssetFields(state);
+
+    expect(derived.averageCost).toBe(100);
+    expect(derived.averageCostEur).toBe(90);
   });
 
   it('orders baseline, then buy before sell, then by createdAt, then by id', () => {

--- a/__tests__/assetTransactionWriteTx.test.ts
+++ b/__tests__/assetTransactionWriteTx.test.ts
@@ -148,6 +148,7 @@ import {
   updateAssetTransaction,
   deleteAssetTransaction,
 } from '@/lib/server/assetTransactionUseCase';
+import { resolveTradePriceEur } from '@/lib/server/tradeFxService';
 
 const OWNER = 'owner-1';
 const BASELINE_DATE = new Date(2024, 0, 1);
@@ -190,13 +191,37 @@ describe('assetTransactionUseCase — atomic write transaction', () => {
       linkedCashAssetId: 'cash-1',
     });
 
-    expect(result.derived).toEqual({ quantity: 10, averageCost: 100 });
+    expect(result.derived).toEqual({ quantity: 10, averageCost: 100, averageCostEur: 100 });
     // 10 units × €100 debited from the cash account.
     expect(store.get(docKey('assets', 'cash-1'))!.quantity).toBe(9000);
     const asset = store.get(docKey('assets', 'asset-1'))!;
     expect(asset.quantity).toBe(10);
     expect(asset.averageCost).toBe(100);
+    expect(asset.averageCostEur).toBe(100);
     expect(invalidateMock).toHaveBeenCalledWith(OWNER, 'asset_transaction_created');
+  });
+
+  it('writes a EUR-side averageCostEur distinct from the native averageCost for a foreign-currency buy', async () => {
+    // A USD trade at 100 USD/quota, but the trade-date rate made it 90 EUR/quota: the native PMC
+    // and the EUR PMC must diverge on the asset doc, otherwise G/P math re-mixes the two currencies
+    // (the bug this write path exists to prevent).
+    vi.mocked(resolveTradePriceEur).mockResolvedValueOnce(90);
+    seedAsset({ quantity: 0, currency: 'USD' });
+    seedCash('cash-1', 10000);
+
+    const result = await createAssetTransaction(OWNER, {
+      assetId: 'asset-1',
+      type: 'buy',
+      date: new Date(),
+      quantity: 10,
+      pricePerUnit: 100,
+      linkedCashAssetId: 'cash-1',
+    });
+
+    expect(result.derived).toEqual({ quantity: 10, averageCost: 100, averageCostEur: 90 });
+    const asset = store.get(docKey('assets', 'asset-1'))!;
+    expect(asset.averageCost).toBe(100); // native PMC, USD
+    expect(asset.averageCostEur).toBe(90); // EUR PMC at the trade-date rate
   });
 
   it('moves the settlement to a different cash account with two aggregated deltas', async () => {

--- a/__tests__/patrimonioSummary.test.ts
+++ b/__tests__/patrimonioSummary.test.ts
@@ -25,6 +25,7 @@ vi.mock('firebase/firestore', () => ({
 import {
   computeTopWeightShare,
   computeUnrealizedGain,
+  hasCostBasis,
   isCashAccount,
   isHeld,
   rankInstrumentReturns,
@@ -193,6 +194,49 @@ describe('summarizeUnrealizedGains', () => {
 
   it('should report a null percentage when nothing has a cost basis', () => {
     expect(summarizeUnrealizedGains([makeAsset()])).toEqual({ gainLoss: 0, costBasis: 0, gainPercent: null, count: 0 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeUnrealizedGain / hasCostBasis / summarizeUnrealizedGains — currency
+// ---------------------------------------------------------------------------
+
+describe('foreign-currency G/P (averageCostEur, never averageCost against the EUR value)', () => {
+  it('compares averageCostEur to the EUR value, not the native averageCost', () => {
+    // 10 units bought at 100 USD/quota (90 EUR/quota at the trade date), now worth 130 EUR/quota.
+    // Mixing currencies would read costBasis = 10·100 = 1000 and gainLoss = 1300 − 1000 = 300 (+30%).
+    // The correct EUR-side comparison is costBasis = 10·90 = 900, gainLoss = 1300 − 900 = 400 (+44.4%).
+    const asset = makeAsset({
+      currency: 'USD',
+      quantity: 10,
+      currentPrice: 145,
+      currentPriceEur: 130,
+      averageCost: 100,
+      averageCostEur: 90,
+    });
+    expect(computeUnrealizedGain(asset)).toEqual({ gainLoss: 400, gainPercent: 400 / 9 });
+  });
+
+  it('falls back to averageCost for a EUR-native asset without averageCostEur (pre-backfill data)', () => {
+    const asset = makeAsset({ currency: 'EUR', quantity: 10, currentPrice: 120, averageCost: 100 });
+    expect(hasCostBasis(asset)).toBe(true);
+    expect(computeUnrealizedGain(asset)).toEqual({ gainLoss: 200, gainPercent: 20 });
+  });
+
+  it('has no comparable basis for a foreign-currency asset that predates averageCostEur', () => {
+    // Pre-backfill: only the native PMC is on the doc. Showing a G/P here would be exactly today's
+    // bug (native PMC vs EUR value), so this must read as "no basis" until the backfill runs.
+    const asset = makeAsset({ currency: 'USD', quantity: 10, currentPrice: 145, currentPriceEur: 130, averageCost: 100 });
+    expect(hasCostBasis(asset)).toBe(false);
+    expect(computeUnrealizedGain(asset)).toBeNull();
+  });
+
+  it('sums foreign- and EUR-currency positions in one EUR-side total', () => {
+    const assets = [
+      makeAsset({ id: 'usd', currency: 'USD', quantity: 10, currentPrice: 145, currentPriceEur: 130, averageCost: 100, averageCostEur: 90 }),
+      makeAsset({ id: 'eur', currency: 'EUR', quantity: 10, currentPrice: 120, averageCost: 100 }),
+    ];
+    expect(summarizeUnrealizedGains(assets)).toEqual({ gainLoss: 600, costBasis: 1900, gainPercent: 600 / 19, count: 2 });
   });
 });
 

--- a/app/api/asset-transactions/backfill-average-cost-eur/route.ts
+++ b/app/api/asset-transactions/backfill-average-cost-eur/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  assertCanAccessAccount,
+  requireFirebaseAuth,
+} from '@/lib/server/apiAuth';
+import { backfillAverageCostEur } from '@/lib/server/assetTransactionUseCase';
+import { getTradeErrorResponse } from '../errorResponse';
+
+/**
+ * POST /api/asset-transactions/backfill-average-cost-eur
+ *
+ * Idempotent, per-user one-shot: projects `averageCostEur` (a EUR-denominated PMC) onto ledger
+ * asset docs written before the field existed, fixing G/P for foreign-currency positions (it was
+ * comparing a native-currency PMC against a EUR value). Body: { userId }. A second call after the
+ * backfill returns { alreadyBackfilled: true }.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const decodedToken = await requireFirebaseAuth(request);
+
+    const body = (await request.json().catch(() => ({}))) as { userId?: unknown };
+    const ownerId = typeof body.userId === 'string' ? body.userId : null;
+    await assertCanAccessAccount(decodedToken, ownerId);
+
+    const result = await backfillAverageCostEur(ownerId as string);
+    return NextResponse.json(result);
+  } catch (error) {
+    return getTradeErrorResponse(error, 'POST /api/asset-transactions/backfill-average-cost-eur');
+  }
+}

--- a/app/dashboard/assets/page.tsx
+++ b/app/dashboard/assets/page.tsx
@@ -33,7 +33,7 @@ import { useActiveAccount } from '@/contexts/ActiveAccountContext';
 import { useAssets, useDeleteAsset } from '@/lib/hooks/useAssets';
 import { calculateTotalValue } from '@/lib/services/assetService';
 import { useAssetLedgerMeta, useAssetTransactions } from '@/lib/hooks/useAssetTransactions';
-import { migrateAssetLedger } from '@/lib/services/assetTransactionService';
+import { migrateAssetLedger, backfillAverageCostEur } from '@/lib/services/assetTransactionService';
 import { useSnapshots } from '@/lib/hooks/useSnapshots';
 import { useDashboardOverview } from '@/lib/hooks/useDashboardOverview';
 import { useChartColors } from '@/lib/hooks/useChartColors';
@@ -125,6 +125,29 @@ export default function AssetsPage() {
       })
       .catch((error) => {
         console.error('[AssetsPage] Ledger migration failed:', error);
+      });
+  }, [ownerId, isLedgerMetaLoading, ledgerMeta, queryClient]);
+
+  // ─── averageCostEur backfill trigger ───────────────────────────────────────────
+  // One-shot, post-migration: projects the EUR-side PMC onto ledger assets written before the
+  // field existed, so G/P on a foreign-currency position stops comparing a native-currency PMC
+  // against a EUR value. Silent, same posture as the migration above.
+  const averageCostEurBackfillAttemptedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!ownerId || isLedgerMetaLoading || !ledgerMeta) return;
+    if (ledgerMeta.averageCostEurBackfilledAt) return;
+    if (averageCostEurBackfillAttemptedRef.current === ownerId) return;
+    averageCostEurBackfillAttemptedRef.current = ownerId;
+
+    backfillAverageCostEur(ownerId)
+      .then(() => {
+        queryClient.invalidateQueries({ queryKey: queryKeys.assetTransactions.meta(ownerId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.assets.all(ownerId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.dashboard.overview(ownerId) });
+      })
+      .catch((error) => {
+        console.error('[AssetsPage] averageCostEur backfill failed:', error);
       });
   }, [ownerId, isLedgerMetaLoading, ledgerMeta, queryClient]);
 

--- a/lib/server/assetTransactionUseCase.ts
+++ b/lib/server/assetTransactionUseCase.ts
@@ -64,7 +64,7 @@ export class TradeUseCaseError extends Error {
 
 export interface TradeMutationResult {
   transactionId: string;
-  derived: { quantity: number; averageCost: number | undefined };
+  derived: { quantity: number; averageCost: number | undefined; averageCostEur: number | undefined };
   /** Realized P&L of THIS operation (present only for sells) — lets the UI toast without refetch. */
   realizedPnlEur?: number;
 }
@@ -373,9 +373,15 @@ async function prepareDelete(ownerId: string, transactionId: string): Promise<Pr
 
 async function commitTradeMutation(
   plan: PreparedMutation
-): Promise<{ derived: { quantity: number; averageCost: number | undefined }; realizedDelta?: number }> {
+): Promise<{
+  derived: { quantity: number; averageCost: number | undefined; averageCostEur: number | undefined };
+  realizedDelta?: number;
+}> {
   let outcome:
-    | { derived: { quantity: number; averageCost: number | undefined }; realizedDelta?: number }
+    | {
+        derived: { quantity: number; averageCost: number | undefined; averageCostEur: number | undefined };
+        realizedDelta?: number;
+      }
     | undefined;
 
   await adminDb.runTransaction(async (tx: Transaction) => {
@@ -433,12 +439,14 @@ async function commitTradeMutation(
     // w2: derived asset fields. NEVER deleteField() holdingStartDate — undefined means "leave
     // untouched"; removeUndefinedDeep drops the undefined key so the
     // stored value survives. Written directly, NOT via updateAsset (whose undefined→deleteField()
-    // for averageCost is exactly the trap we avoid).
+    // for averageCost is exactly the trap we avoid). Same "leave untouched at qty 0" posture for
+    // averageCostEur as for averageCost — see buildDerivedAssetFields.
     tx.update(
       assetRef,
       removeUndefinedDeep({
         quantity: derived.quantity,
         averageCost: derived.averageCost,
+        averageCostEur: derived.averageCostEur,
         updatedAt: new Date(),
         ...(derived.holdingStartDate !== undefined ? { holdingStartDate: derived.holdingStartDate } : {}),
       })
@@ -456,7 +464,10 @@ async function commitTradeMutation(
       tx.update(ref, { quantity: currentQuantity + delta, updatedAt: new Date() });
     }
 
-    outcome = { derived: { quantity: derived.quantity, averageCost: derived.averageCost }, realizedDelta };
+    outcome = {
+      derived: { quantity: derived.quantity, averageCost: derived.averageCost, averageCostEur: derived.averageCostEur },
+      realizedDelta,
+    };
   });
 
   if (!outcome) {
@@ -623,4 +634,69 @@ export async function migrateAssetLedger(ownerId: string): Promise<MigrationResu
   );
 
   return { migratedAssetCount: ledgerAssets.length, baselineDate };
+}
+
+// ---------------------------------------------------------------------------
+// averageCostEur backfill (idempotent, per-user, server-side)
+// ---------------------------------------------------------------------------
+
+export type AverageCostEurBackfillResult =
+  | { alreadyBackfilled: true }
+  | { alreadyBackfilled?: false; recomputedAssetCount: number };
+
+/**
+ * One-shot backfill of `averageCostEur` onto ledger asset docs that predate the field. No new FX
+ * lookups: every trade has carried a correct trade-date `priceEur` since the ledger shipped
+ * (including the migration baseline — resolveBaselinePriceEur), so this is a pure re-projection of
+ * data already in `assetTransactions` via buildDerivedAssetFields, exactly what every trade mutation
+ * already writes going forward (commitTradeMutation). Only rewrites quantity/averageCost/averageCostEur
+ * — the fields buildDerivedAssetFields projects — never holdingStartDate (invariant #4).
+ *
+ * Idempotent — `averageCostEurBackfilledAt` on the ledger meta doc is the "done" signal. Requires the
+ * meta doc to already exist (ledger migration must have run first, and the caller is expected to have
+ * awaited migrateAssetLedger before this): with no meta doc yet there is nothing to backfill, and this
+ * returns a no-op WITHOUT creating one, so it can never be mistaken by migrateAssetLedger for
+ * "already migrated".
+ */
+export async function backfillAverageCostEur(ownerId: string): Promise<AverageCostEurBackfillResult> {
+  const metaRef = adminDb.collection(ASSET_TRANSACTIONS_META_COLLECTION).doc(ownerId);
+  const metaSnap = await metaRef.get();
+  if (!metaSnap.exists || metaSnap.data()?.averageCostEurBackfilledAt) {
+    return { alreadyBackfilled: true };
+  }
+
+  const assets = await getUserAssetsAdmin(ownerId);
+  const ledgerAssets = assets.filter((a) => isLedgerAssetType(a.type) && a.quantity > 0);
+
+  let recomputedAssetCount = 0;
+  for (const asset of ledgerAssets) {
+    const tradesSnap = await adminDb
+      .collection(ASSET_TRANSACTIONS_COLLECTION)
+      .where('userId', '==', ownerId)
+      .where('assetId', '==', asset.id)
+      .get();
+    if (tradesSnap.empty) continue;
+
+    const trades = tradesSnap.docs.map((d) => docToAssetTransaction(d.id, d.data() as DocumentData));
+    const state = replayTransactions(trades);
+    const derived = buildDerivedAssetFields(state);
+    await adminDb.collection(ASSETS_COLLECTION).doc(asset.id).update(
+      removeUndefinedDeep({
+        quantity: derived.quantity,
+        averageCost: derived.averageCost,
+        averageCostEur: derived.averageCostEur,
+        updatedAt: new Date(),
+      })
+    );
+    recomputedAssetCount += 1;
+  }
+
+  await metaRef.update({ averageCostEurBackfilledAt: new Date(), updatedAt: new Date() });
+
+  // The overview payload's topAssets.returnPercent reads averageCostEur too (dashboardOverviewService).
+  if (recomputedAssetCount > 0) {
+    await invalidateDashboardOverviewSummaryServer(ownerId, 'average_cost_eur_backfilled');
+  }
+
+  return { recomputedAssetCount };
 }

--- a/lib/services/assetTransactionService.ts
+++ b/lib/services/assetTransactionService.ts
@@ -35,7 +35,7 @@ import {
 /** Server response for a create/edit/delete (mirrors TradeMutationResult in the use case). */
 export interface AssetTransactionMutationResult {
   transactionId: string;
-  derived: { quantity: number; averageCost?: number };
+  derived: { quantity: number; averageCost?: number; averageCostEur?: number };
   realizedPnlEur?: number;
 }
 
@@ -96,6 +96,8 @@ export async function getAssetLedgerMeta(ownerId: string): Promise<AssetTransact
     migratedAt: toDate(data.migratedAt as never),
     baselineDate: toDate(data.baselineDate as never),
     migratedAssetCount: data.migratedAssetCount as number,
+    averageCostEurBackfilledAt:
+      data.averageCostEurBackfilledAt !== undefined ? toDate(data.averageCostEurBackfilledAt as never) : undefined,
     createdAt: toDate(data.createdAt as never),
     updatedAt: toDate(data.updatedAt as never),
   };
@@ -189,4 +191,18 @@ export async function migrateAssetLedger(ownerId: string): Promise<AssetLedgerMi
     body: JSON.stringify({ userId: ownerId }),
   });
   return parseWriteResponse(response, 'Errore durante la migrazione del registro operazioni.');
+}
+
+export type AverageCostEurBackfillResult =
+  | { alreadyBackfilled: true }
+  | { alreadyBackfilled?: false; recomputedAssetCount: number };
+
+/** Idempotent averageCostEur backfill for the owner. Silent no-op once already run. */
+export async function backfillAverageCostEur(ownerId: string): Promise<AverageCostEurBackfillResult> {
+  const response = await authenticatedFetch('/api/asset-transactions/backfill-average-cost-eur', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId: ownerId }),
+  });
+  return parseWriteResponse(response, 'Errore durante il ricalcolo del PMC in euro.');
 }

--- a/lib/services/dashboardOverviewService.ts
+++ b/lib/services/dashboardOverviewService.ts
@@ -46,6 +46,7 @@ import {
 import { calculateMonthlyChange, calculateYearlyChange } from '@/lib/services/snapshotService';
 import { getItalyMonthYear, ITALY_TIMEZONE, toDate } from '@/lib/utils/dateHelpers';
 import { getAssetDisplayTicker } from '@/lib/utils/assetDisplay';
+import { costBasisPerUnitEur } from '@/lib/utils/patrimonioSummary';
 import {
   DASHBOARD_OVERVIEW_SOURCE_VERSION,
   DASHBOARD_OVERVIEW_SUMMARY_COLLECTION,
@@ -403,10 +404,12 @@ function buildLiveOverviewPayload(
     .filter(a => a.quantity > 0)
     .map(a => {
       const value = calculateAssetValue(a);
-      // Use null instead of undefined — Firestore rejects undefined values.
+      // Use null instead of undefined — Firestore rejects undefined values. Compared in EUR on both
+      // sides (costBasisPerUnitEur), never the native-currency averageCost against the EUR value.
       let returnPercent: number | null = null;
-      if (a.averageCost && a.averageCost > 0) {
-        const costBasis = a.quantity * a.averageCost;
+      const basisPerUnit = costBasisPerUnitEur(a);
+      if (basisPerUnit && basisPerUnit > 0) {
+        const costBasis = a.quantity * basisPerUnit;
         returnPercent = costBasis > 0 ? ((value - costBasis) / costBasis) * 100 : null;
       }
       return {

--- a/lib/utils/assetTransactionUtils.ts
+++ b/lib/utils/assetTransactionUtils.ts
@@ -283,18 +283,22 @@ export function replayTransactions(transactions: AssetTransaction[]): LedgerPosi
 
 /**
  * Project the replay result into the exact fields written back to assets/{assetId}. Single tested
- * source of truth for the write path. `averageCost: undefined` can only occur for an empty
- * sequence (the route never writes in that case); `holdingStartDate: undefined` means "do not
+ * source of truth for the write path. `averageCost`/`averageCostEur: undefined` can only occur for
+ * an empty sequence (the route never writes in that case) or, for `averageCostEur` alone, when the
+ * position just closed (quantity 0 — see the clamp in replayTransactionsWithEffects, harmless since
+ * every G/P consumer filters on quantity > 0 first); `holdingStartDate: undefined` means "do not
  * write" (see §holdingStartDate).
  */
 export function buildDerivedAssetFields(state: LedgerPositionState): {
   quantity: number;
   averageCost: number | undefined;
+  averageCostEur: number | undefined;
   holdingStartDate: Date | undefined;
 } {
   return {
     quantity: state.quantity,
     averageCost: state.averageCost,
+    averageCostEur: state.averageCostEur,
     holdingStartDate: state.holdingStartDate,
   };
 }

--- a/lib/utils/patrimonioSummary.ts
+++ b/lib/utils/patrimonioSummary.ts
@@ -131,6 +131,19 @@ export interface UnrealizedGainsSummary {
 }
 
 /**
+ * The EUR-denominated PMC to compare against `calculateAssetValue` (itself always EUR) — never
+ * the native `averageCost`, which would mix a foreign-currency PMC with a EUR value. Falls back to
+ * `averageCost` only for a EUR-native asset (the two are identical by construction there) or for an
+ * asset that predates `averageCostEur` and has not had a ledger mutation since; a non-EUR asset
+ * without `averageCostEur` yet has no comparable basis at all.
+ */
+export function costBasisPerUnitEur(asset: Asset): number | undefined {
+  if (asset.averageCostEur !== undefined && asset.averageCostEur > 0) return asset.averageCostEur;
+  if (asset.currency.toUpperCase() === 'EUR') return asset.averageCost;
+  return undefined;
+}
+
+/**
  * Whether an asset's G/P against its PMC is meaningful. Cash accounts do not represent invested
  * capital (their cost basis would dilute the percentage without adding any gain), and a pension
  * fund's leftover `averageCost` from a type conversion is not a PMC — its exit taxation is a
@@ -138,16 +151,19 @@ export interface UnrealizedGainsSummary {
  */
 export function hasCostBasis(asset: Asset): boolean {
   if (isCashAccount(asset) || asset.type === 'pensionFund' || !isHeld(asset)) return false;
-  return !!asset.averageCost && asset.averageCost > 0;
+  const basis = costBasisPerUnitEur(asset);
+  return basis !== undefined && basis > 0;
 }
 
 /**
  * One position's G/P against its PMC — the figure the table cell, the mobile row and the sort
- * share. Null when `hasCostBasis` says there is no PMC to measure against.
+ * share. Both sides of the subtraction are EUR (see `costBasisPerUnitEur`), so a foreign-currency
+ * position is never measured against its own native-currency PMC. Null when `hasCostBasis` says
+ * there is no PMC to measure against.
  */
 export function computeUnrealizedGain(asset: Asset): { gainLoss: number; gainPercent: number } | null {
   if (!hasCostBasis(asset)) return null;
-  const basis = asset.quantity * (asset.averageCost as number);
+  const basis = asset.quantity * (costBasisPerUnitEur(asset) as number);
   const gainLoss = calculateAssetValue(asset) - basis;
   return { gainLoss, gainPercent: basis > 0 ? (gainLoss / basis) * 100 : 0 };
 }
@@ -160,7 +176,7 @@ export function summarizeUnrealizedGains(assets: Asset[]): UnrealizedGainsSummar
     const gain = computeUnrealizedGain(asset);
     if (!gain) continue;
     gainLoss += gain.gainLoss;
-    costBasis += asset.quantity * (asset.averageCost as number);
+    costBasis += asset.quantity * (costBasisPerUnitEur(asset) as number);
     count += 1;
   }
   return {

--- a/types/assetTransactions.ts
+++ b/types/assetTransactions.ts
@@ -79,6 +79,11 @@ export interface AssetTransactionsMeta {
   migratedAt: Date;
   baselineDate: Date;        // start-of-day (Italy) of migration day; global floor for trade dates
   migratedAssetCount: number;
+  // One-shot signal for backfillAverageCostEur (assetTransactionUseCase.ts): every ledger asset's
+  // averageCostEur is derivable from trades that already carry a correct per-trade priceEur, so the
+  // backfill only needs to run once, after migration, to project it onto pre-existing asset docs.
+  // Absent until the backfill has run for this owner.
+  averageCostEurBackfilledAt?: Date;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/types/assets.ts
+++ b/types/assets.ts
@@ -125,6 +125,12 @@ export interface Asset {
   // ledger is the source of truth. cash/realestate keep direct editing and have no ledger.
   quantity: number;
   averageCost?: number; // Native-currency PMC (weighted avg of trade prices, fees excluded). Derived for ledger types — see note on `quantity`.
+  // EUR-equivalent PMC (costBasisEur / quantity — fees and the trade-date FX rate included), same
+  // derivation and lifecycle as `averageCost`. G/P math MUST compare this against the EUR value
+  // (calculateAssetValue), never `averageCost` against it — that mixes a native-currency PMC with a
+  // EUR value. Absent for cash/realestate (no ledger) and, until their next ledger mutation, for
+  // assets that predate this field.
+  averageCostEur?: number;
   taxRate?: number; // Tax rate percentage for unrealized gains (e.g., 26 for 26%)
   totalExpenseRatio?: number; // Total Expense Ratio (TER) as a percentage (e.g., 0.20 for 0.20%)
   stampDutyExempt?: boolean; // If true, asset is excluded from stamp duty (imposta di bollo) calculation (e.g. pension funds, real estate)


### PR DESCRIPTION
# Patrimonio: il G/P confronta due valute diverse su una posizione estera

> **Aperta il 2026-09-01 come PR verso `develop` di upstream, dal branch
> `pr/patrimonio-pmc-eur` (`upstream/develop` + un solo commit).**
>
> Questo file è il corpo inviato a GitHub. Vale la regola del repo: il corpo non cita mai file che
> esistono solo in questo fork.

## Il problema

`computeUnrealizedGain` (e la copia server-side in `dashboardOverviewService.ts` che alimenta
`topAssets.returnPercent`) calcola il G/P come `calculateAssetValue(asset) − quantity · averageCost`.
`calculateAssetValue` è sempre in EUR (converte con `currentPriceEur`); `averageCost` è invece il
PMC nella **valuta nativa** del titolo — dollari, sterline, franchi svizzeri.

Per un titolo in EUR i due lati coincidono e il bug è invisibile. Per un titolo estero il segno e
l'ampiezza del G/P dipendono dal cambio corrente rispetto al cambio medio d'acquisto, non solo
dall'andamento del titolo: un titolo USD comprato quando l'euro era forte e rivenduto (sulla carta)
quando l'euro è debole legge un G/P inflazionato anche a prezzo nativo fermo, o viceversa un G/P
compresso o negativo con il titolo in utile.

Il motore che ricostruisce la posizione dal registro operazioni (`assetTransactionUtils.ts`)
calcola già, per ogni operazione, il controvalore in EUR al cambio della data del trade
(`AssetTransaction.priceEur`, risolto da `tradeFxService.resolveTradePriceEur`), e ne deriva un PMC
in EUR (`costBasisEur / quantity`) dentro `LedgerPositionState`. Quel numero non arrivava mai sul
documento asset: `buildDerivedAssetFields` proiettava solo il PMC nativo.

## La correzione

- **`averageCostEur`**, nuovo campo su `Asset`, proiettato da `buildDerivedAssetFields` insieme al
  PMC nativo esistente e scritto sul documento asset ad ogni mutazione del registro operazioni
  (`commitTradeMutation`) — stessa vita di `averageCost`, stessa regola "lasciato intatto a
  quantità zero".
- **`costBasisPerUnitEur`**, unica funzione che risolve il PMC da confrontare con il valore EUR:
  usa `averageCostEur` quando presente, altrimenti ricade su `averageCost` solo per un asset già in
  EUR (dove i due coincidono per costruzione). `hasCostBasis`/`computeUnrealizedGain`/
  `summarizeUnrealizedGains` e il calcolo di `topAssets.returnPercent` la condividono, così il G/P
  della tabella, la percentuale sotto il valore e il ranking del Rendimento non possono divergere.
- **`backfillAverageCostEur`**, ricalcolo one-shot idempotente per le posizioni già esistenti: non
  servono nuove chiamate al cambio, perché ogni operazione — baseline di migrazione inclusa — porta
  già un `priceEur` corretto dalla propria data. È una pura riproiezione via
  `replayTransactions` + `buildDerivedAssetFields`, stesso schema della migrazione del registro
  (meta doc come segnale "fatto", innescato una volta sola all'apertura della pagina).

## Profilo di rischio

Nessun cambiamento per un asset in EUR: `costBasisPerUnitEur` ricade su `averageCost`, identico a
prima. Cambia solo il G/P mostrato per una posizione in valuta estera — dove oggi mescola due
valute — e solo dopo che il backfill ha popolato `averageCostEur` (silenzioso, un'unica volta per
utente).

## Verifica

`tsc` pulito, suite Vitest verde sotto `TZ=Europe/Rome`. Test nuovi su `buildDerivedAssetFields`
(un trade con FX diverso dal prezzo nativo produce due PMC distinti), sul path di scrittura atomico
(`commitTradeMutation` proietta `averageCostEur`), sul backfill (no-op prima della migrazione,
no-op se già eseguito, ricalcolo corretto, idempotente) e su `computeUnrealizedGain`/
`hasCostBasis`/`summarizeUnrealizedGains` (il confronto in EUR contro il vecchio mix di valute, il
fallback per un asset EUR-nativo, l'assenza di base comparabile per un asset estero che precede il
backfill).
