### PR TITLE
Cashflow › Tracciamento: la ricerca nei movimenti diventa un aggregato

### DIFF
--- a/__tests__/cashflowNarrative.test.ts
+++ b/__tests__/cashflowNarrative.test.ts
@@ -426,25 +426,39 @@ describe('describeScheduledHorizon', () => {
 });
 
 describe('describeMovements', () => {
-  it('should count the rows by type and name the largest', () => {
-    const summary = { count: 47, expenseCount: 40, incomeCount: 5, transferCount: 2, largest: { label: 'Stipendio', amount: 4200, type: 'income' as const }, scheduled: NO_SCHEDULED };
-    expect(plain(describeMovements(summary))).toBe('47 movimenti: 40 spese, 5 entrate e 2 trasferimenti; la voce più grande è Stipendio (4200 €).');
+  it('should count the rows by type, sum each type and name the largest', () => {
+    const summary = { count: 47, expenseCount: 40, incomeCount: 5, transferCount: 2, expenseTotal: 3200, incomeTotal: 4500, transferTotal: 500, largest: { label: 'Stipendio', amount: 4200, type: 'income' as const }, scheduled: NO_SCHEDULED };
+    expect(plain(describeMovements(summary))).toBe(
+      '47 movimenti: 40 spese per 3200 €, 5 entrate per 4500 € e 2 trasferimenti per 500 €; la voce più grande è Stipendio (4200 €).',
+    );
+  });
+
+  it('should total a search on one note, which is what makes the reading an aggregate', () => {
+    expect(
+      plain(describeMovements({ count: 120, expenseCount: 120, incomeCount: 0, transferCount: 0, expenseTotal: 264, incomeTotal: 0, transferTotal: 0, largest: { label: 'caffè', amount: 4, type: 'variable' as const }, scheduled: NO_SCHEDULED })),
+    ).toBe('120 movimenti: 120 spese per 264 €; la voce più grande è caffè (4 €).');
+  });
+
+  it('should keep the minus on an income total reversed to below zero', () => {
+    expect(
+      plain(describeMovements({ count: 1, expenseCount: 0, incomeCount: 1, transferCount: 0, expenseTotal: 0, incomeTotal: -200, transferTotal: 0, largest: { label: 'Storno', amount: 200, type: 'income' as const }, scheduled: NO_SCHEDULED })),
+    ).toBe('1 movimento: 1 entrata per −200 €; la voce più grande è Storno (200 €).');
   });
 
   it('should drop an empty type and decline the singulars', () => {
-    expect(plain(describeMovements({ count: 2, expenseCount: 1, incomeCount: 1, transferCount: 0, largest: { label: 'Casa', amount: 800, type: 'fixed' as const }, scheduled: NO_SCHEDULED }))).toBe(
-      '2 movimenti: 1 spesa e 1 entrata; la voce più grande è Casa (800 €).',
+    expect(plain(describeMovements({ count: 2, expenseCount: 1, incomeCount: 1, transferCount: 0, expenseTotal: 800, incomeTotal: 1500, transferTotal: 0, largest: { label: 'Casa', amount: 800, type: 'fixed' as const }, scheduled: NO_SCHEDULED }))).toBe(
+      '2 movimenti: 1 spesa per 800 € e 1 entrata per 1500 €; la voce più grande è Casa (800 €).',
     );
-    expect(plain(describeMovements({ count: 1, expenseCount: 0, incomeCount: 0, transferCount: 1, largest: { label: 'Giroconto', amount: 300, type: 'transfer' as const }, scheduled: NO_SCHEDULED }))).toBe(
-      '1 movimento: 1 trasferimento; la voce più grande è Giroconto (300 €).',
+    expect(plain(describeMovements({ count: 1, expenseCount: 0, incomeCount: 0, transferCount: 1, expenseTotal: 0, incomeTotal: 0, transferTotal: 300, largest: { label: 'Giroconto', amount: 300, type: 'transfer' as const }, scheduled: NO_SCHEDULED }))).toBe(
+      '1 movimento: 1 trasferimento per 300 €; la voce più grande è Giroconto (300 €).',
     );
-    expect(describeMovements({ count: 0, expenseCount: 0, incomeCount: 0, transferCount: 0, largest: null, scheduled: NO_SCHEDULED })).toBeNull();
+    expect(describeMovements({ count: 0, expenseCount: 0, incomeCount: 0, transferCount: 0, expenseTotal: 0, incomeTotal: 0, transferTotal: 0, largest: null, scheduled: NO_SCHEDULED })).toBeNull();
   });
 
   it('should name the scheduled rows — the clause that keeps the list honest against the tiles', () => {
     expect(
-      plain(describeMovements({ count: 47, expenseCount: 40, incomeCount: 5, transferCount: 2, largest: { label: 'Stipendio', amount: 4200, type: 'income' as const }, scheduled: { count: 2, total: 406 } })),
-    ).toBe('47 movimenti: 40 spese, 5 entrate e 2 trasferimenti, di cui 2 in calendario (406 €); la voce più grande è Stipendio (4200 €).');
+      plain(describeMovements({ count: 47, expenseCount: 40, incomeCount: 5, transferCount: 2, expenseTotal: 3200, incomeTotal: 4500, transferTotal: 500, largest: { label: 'Stipendio', amount: 4200, type: 'income' as const }, scheduled: { count: 2, total: 406 } })),
+    ).toBe('47 movimenti: 40 spese per 3200 €, 5 entrate per 4500 € e 2 trasferimenti per 500 €, di cui 2 in calendario (406 €); la voce più grande è Stipendio (4200 €).');
   });
 
   it('should size the aside as shown of total when the list is filtered', () => {

--- a/__tests__/tracciamentoSummary.test.ts
+++ b/__tests__/tracciamentoSummary.test.ts
@@ -341,6 +341,46 @@ describe('summarizeMovements', () => {
     expect(summary.largest).toEqual({ label: 'Stipendio', amount: 4200, type: 'income' });
   });
 
+  it('should sum each type the way the page does: spending as a magnitude, income signed, transfers as moved', () => {
+    const summary = summarizeMovements(AUGUST_ROWS, NOW);
+
+    expect(summary.expenseTotal).toBe(2910);
+    expect(summary.incomeTotal).toBe(4850);
+    expect(summary.transferTotal).toBe(1500);
+  });
+
+  it('should classify the totals by type, not by sign: a positive spending row still raises the spending total', () => {
+    const summary = summarizeMovements(
+      [
+        makeExpense({ type: 'income', amount: 1000, date: d(2026, 8) }),
+        makeExpense({ type: 'income', amount: -100, date: d(2026, 8) }),
+        makeExpense({ type: 'variable', amount: 50, date: d(2026, 8) }),
+        makeExpense({ type: 'variable', amount: -400, date: d(2026, 8) }),
+      ],
+      NOW,
+    );
+
+    expect(summary.incomeTotal).toBe(900);
+    expect(summary.expenseTotal).toBe(450);
+  });
+
+  it('should sum the rows it is handed: a search on one note is its own total', () => {
+    // One recurring note used as an implicit subcategory. The list is already filtered by the
+    // toolbar — summarizeMovements only totals what it receives.
+    const summary = summarizeMovements(
+      [
+        makeExpense({ type: 'variable', amount: -1.2, categoryName: 'Bar', notes: 'caffè', date: d(2026, 3) }),
+        makeExpense({ type: 'variable', amount: -1.2, categoryName: 'Bar', notes: 'caffè', date: d(2026, 5) }),
+        makeExpense({ type: 'variable', amount: -2.6, categoryName: 'Bar', notes: 'caffè', date: d(2026, 8) }),
+      ],
+      NOW,
+    );
+
+    expect(summary).toMatchObject({ count: 3, expenseCount: 3, incomeCount: 0, transferCount: 0 });
+    expect(summary.expenseTotal).toBeCloseTo(5, 5);
+    expect(summary.largest).toEqual({ label: 'caffè', amount: 2.6, type: 'variable' });
+  });
+
   it('should label the largest by its note when there is one', () => {
     const summary = summarizeMovements(
       [makeExpense({ type: 'fixed', amount: -820, categoryName: 'Casa', notes: 'Rata mutuo ', date: d(2026, 8) })],
@@ -377,6 +417,9 @@ describe('summarizeMovements', () => {
       expenseCount: 0,
       incomeCount: 0,
       transferCount: 0,
+      expenseTotal: 0,
+      incomeTotal: 0,
+      transferTotal: 0,
       largest: null,
       scheduled: { count: 0, total: 0 },
     });

--- a/components/cashflow/ExpenseTrackingTab.tsx
+++ b/components/cashflow/ExpenseTrackingTab.tsx
@@ -6,8 +6,9 @@
  * picker, and under it a 12-column bento of tiles, each answering ONE question with a reading
  * line over its figures. The inventory (TransactionFeed / ExpenseTable) is the last tile.
  *
- *   Mobile (1 col):   Verdict → [periodo · Filtri · ordina] → Cashflow del periodo → Spese per
- *                     categoria → Entrate per categoria → Risparmio nel tempo → Movimenti
+ *   Mobile (1 col):   Verdict → [periodo] → Cashflow del periodo → Spese per categoria →
+ *                     Entrate per categoria → Risparmio nel tempo → Movimenti, whose own bar
+ *                     repeats the period next to [Filtri · ordina]
  *   Desktop (12 col): Cashflow del periodo (5, 2 rows) | Spese (4) | Entrate (3)
  *                                                      | Risparmio nel tempo (7)
  *                     Movimenti (12)
@@ -719,10 +720,12 @@ export function ExpenseTrackingTab({
     </Link>
   );
 
-  // The phone's filters sit INSIDE the tile they narrow (the period stays beside the verdict).
+  // The phone's filters sit INSIDE the tile they narrow, and so does a second handle on the
+  // period: a search is read over a window ("quanto ho speso di caffè quest'anno?"), and with
+  // the only picker four tiles up, changing the window meant scrolling away from the answer.
+  // The two pickers drive the SAME `period` — one axis with two handles, never two axes.
   const mobileToolbar = (
     <MobileFiltersDrawer
-      showPeriod={false}
       period={period}
       onPeriodChange={setPeriod}
       availableYears={availableYears}

--- a/components/cashflow/MobileFiltersDrawer.tsx
+++ b/components/cashflow/MobileFiltersDrawer.tsx
@@ -66,15 +66,16 @@ export interface MobileFiltersDrawerProps {
   mobileSortKey?: string;
   onSortChange?: (key: string) => void;
   sortOptions?: { value: string; label: string; shortLabel: string }[];
-  /** Render the inline PeriodPicker; Tracciamento keeps the period beside the verdict and passes false. */
-  showPeriod?: boolean;
 }
 
 /**
  * Mobile-only filter bar (hidden on desktop via `desktop:hidden`).
  *
  * Renders a single row:
- *   [PeriodPicker] [Filtri ①]
+ *   [PeriodPicker] [Filtri ①] [⇅]
+ *
+ * The period is the page's axis, repeated here so the window can be changed from beside the
+ * list it slices — a search («caffè») is always read over one.
  *
  * Tapping "Filtri" opens a vaul bottom drawer with:
  *   • Free-text search
@@ -82,7 +83,6 @@ export interface MobileFiltersDrawerProps {
  *   • Subcategory select (conditional)
  *   • Account select (conditional)
  *
- * Sort lives outside this component, in the Voci card header.
  * All filter state lives in the parent — this component is purely presentational.
  */
 export function MobileFiltersDrawer({
@@ -106,21 +106,18 @@ export function MobileFiltersDrawer({
   mobileSortKey,
   onSortChange,
   sortOptions,
-  showPeriod = true,
 }: MobileFiltersDrawerProps) {
   const [open, setOpen] = useState(false);
 
   return (
     <div className="flex items-center justify-center gap-2 desktop:hidden">
       {/* Period picker — max-w caps the button when a custom range label is long */}
-      {showPeriod && (
-        <PeriodPicker
-          value={period}
-          onChange={onPeriodChange}
-          availableYears={availableYears}
-          className="shrink-0 max-w-[170px]"
-        />
-      )}
+      <PeriodPicker
+        value={period}
+        onChange={onPeriodChange}
+        availableYears={availableYears}
+        className="shrink-0 max-w-[170px]"
+      />
 
       {/* Filter button — badge shows count of active drawer filters */}
       <div className="relative shrink-0">

--- a/components/cashflow/tiles/MovimentiTile.tsx
+++ b/components/cashflow/tiles/MovimentiTile.tsx
@@ -9,7 +9,7 @@ interface MovimentiTileProps {
   reading: Narrative | null;
   /** The desktop filter toolbar (search, categories, account, sort, view, export); absent below `desktop:`. */
   toolbar?: ReactNode;
-  /** The phone's «Filtri · ordina» bar, next to the list it narrows; absent from `desktop:`. */
+  /** The phone's «periodo · Filtri · ordina» bar, next to the list it narrows; absent from `desktop:`. */
   mobileToolbar?: ReactNode;
   /** The feed or the table. */
   children: ReactNode;

--- a/lib/utils/cashflowNarrative.ts
+++ b/lib/utils/cashflowNarrative.ts
@@ -508,9 +508,24 @@ export function describeDeficitMonths(history: SavingsHistory, now: Date): Narra
 }
 
 /**
- * "47 movimenti: 40 spese, 5 entrate e 2 trasferimenti, di cui 2 in calendario (406 €); la
- * voce più grande è Stipendio (4200 €)." — the inventory's own count, by type, and its
- * largest row.
+ * "N spese per 3200 €" — a count with the amount it adds up to. A negative total (income
+ * reversed to more than it was received) keeps its minus and its colour, like every other
+ * signed figure of the page.
+ */
+function countWithTotal(count: number, singular: string, plural: string, total: number): Narrative {
+  const amount = total < 0 ? signed(`−${euro(total)}`, 'negative') : figure(euro(total));
+  return [figure(String(count)), prose(` ${pluralize(count, singular, plural)} per `), amount];
+}
+
+/**
+ * "47 movimenti: 40 spese per 3200 €, 5 entrate per 4500 € e 2 trasferimenti per 500 €, di
+ * cui 2 in calendario (406 €); la voce più grande è Stipendio (4200 €)." — the inventory's
+ * own count and sum by type, and its largest row.
+ *
+ * The sums are what makes a free-text search an aggregate: with «caffè» typed in the toolbar
+ * the reading answers «120 movimenti: 120 spese per 264 €», which is the whole point of
+ * reusing one note as an implicit subcategory. They are the sums of the rows the list SHOWS
+ * (`filteredExpenses`), never of the period — that is what the tiles above are for.
  *
  * The «di cui … in calendario» clause is what keeps the list honest: the register lists rows
  * dated after today, the figures above it COUNT them, and this is the sentence that decomposes
@@ -521,10 +536,10 @@ export function describeMovements(summary: MovementsSummary): Narrative | null {
   if (summary.count === 0) return null;
 
   const parts: Narrative[] = [];
-  if (summary.expenseCount > 0) parts.push([figure(String(summary.expenseCount)), prose(` ${pluralize(summary.expenseCount, 'spesa', 'spese')}`)]);
-  if (summary.incomeCount > 0) parts.push([figure(String(summary.incomeCount)), prose(` ${pluralize(summary.incomeCount, 'entrata', 'entrate')}`)]);
+  if (summary.expenseCount > 0) parts.push(countWithTotal(summary.expenseCount, 'spesa', 'spese', summary.expenseTotal));
+  if (summary.incomeCount > 0) parts.push(countWithTotal(summary.incomeCount, 'entrata', 'entrate', summary.incomeTotal));
   if (summary.transferCount > 0) {
-    parts.push([figure(String(summary.transferCount)), prose(` ${pluralize(summary.transferCount, 'trasferimento', 'trasferimenti')}`)]);
+    parts.push(countWithTotal(summary.transferCount, 'trasferimento', 'trasferimenti', summary.transferTotal));
   }
 
   const narrative: Narrative = [figure(String(summary.count)), prose(` ${pluralize(summary.count, 'movimento', 'movimenti')}: `)];

--- a/lib/utils/tracciamentoSummary.ts
+++ b/lib/utils/tracciamentoSummary.ts
@@ -466,6 +466,12 @@ export interface MovementsSummary {
   expenseCount: number;
   incomeCount: number;
   transferCount: number;
+  /** Spending as a magnitude (the `calculateTotalExpenses` convention): a positive row is not income. */
+  expenseTotal: number;
+  /** Income as a SIGNED sum, like `summarizePeriodCashflow`: a reversal lowers the total. */
+  incomeTotal: number;
+  /** The amount MOVED between accounts — an inventory figure, never a flow (a transfer is net-zero). */
+  transferTotal: number;
   /** The row with the largest absolute amount, labelled like the feed (note, else category). */
   largest: { label: string; amount: number; type: ExpenseType } | null;
   /**
@@ -477,21 +483,37 @@ export interface MovementsSummary {
 }
 
 /**
- * The inventory of a list of rows. `now` splits it into what has happened and what is only
- * in the calendar: the register lists both, and the reading must not let them read as one.
+ * The inventory of a list of rows: how many of each type, how much they add up to, the
+ * largest of them. `now` splits it into what has happened and what is only in the calendar:
+ * the register lists both, and the reading must not let them read as one.
+ *
+ * The totals answer «quanto fanno in tutto le righe che sto guardando?» — the question a
+ * free-text search asks when a recurring note ("caffè") is used as an implicit subcategory.
+ * They are the totals of the argument, so with the toolbar narrowing the list they are the
+ * totals of the filtered slice, never of the period.
  */
 export function summarizeMovements(expenses: Expense[], now: Date): MovementsSummary {
   let expenseCount = 0;
   let incomeCount = 0;
   let transferCount = 0;
+  let expenseTotal = 0;
+  let incomeTotal = 0;
+  let transferTotal = 0;
   let scheduledCount = 0;
   let scheduledTotal = 0;
   let largest: Expense | null = null;
   const todayIso = getItalyDateIso(now);
   for (const expense of expenses) {
-    if (expense.type === 'income') incomeCount++;
-    else if (expense.type === 'transfer') transferCount++;
-    else expenseCount++;
+    if (expense.type === 'income') {
+      incomeCount++;
+      incomeTotal += expense.amount;
+    } else if (expense.type === 'transfer') {
+      transferCount++;
+      transferTotal += Math.abs(expense.amount);
+    } else {
+      expenseCount++;
+      expenseTotal += Math.abs(expense.amount);
+    }
     if (isScheduledAfterDay(expense, todayIso)) {
       scheduledCount++;
       scheduledTotal += Math.abs(expense.amount);
@@ -503,6 +525,9 @@ export function summarizeMovements(expenses: Expense[], now: Date): MovementsSum
     expenseCount,
     incomeCount,
     transferCount,
+    expenseTotal,
+    incomeTotal,
+    transferTotal,
     largest: largest
       ? { label: largest.notes?.trim() || largest.categoryName, amount: Math.abs(largest.amount), type: largest.type }
       : null,


### PR DESCRIPTION
## Il problema

Per non moltiplicare le sottocategorie, la stessa tipologia di acquisto viene salvata con la **stessa nota** — «caffè» per i caffè al bar. La ricerca del tile Movimenti diventa così una sottocategoria implicita, ma la lettura del tile sapeva solo **contare** le righe e nominare la più grande. Alla domanda vera — «quanto ho speso di caffè quest'anno?» — la pagina non rispondeva.

Sul telefono, in più, l'unico modo di cambiare la finestra su cui si legge quella ricerca era il picker sotto il verdetto, quattro tessere più su: cambiarlo voleva dire scorrere via dalla risposta.

## Cosa cambia

**1. La somma accanto al conteggio.** `summarizeMovements` porta un totale per tipo, con la convenzione della pagina (AGENTS → *Expense Sign Convention*): spesa come magnitudine, entrata come somma **con segno** (uno storno la abbassa, e `describeMovements` ne tiene il meno e il colore della perdita), trasferimento come **importo mosso** — cifra d'inventario, non un flusso: nessun numero di cashflow ci viene costruito sopra.

La lettura passa da

> 47 movimenti: 40 spese, 5 entrate e 2 trasferimenti, di cui 2 in calendario (406 €); la voce più grande è Stipendio (4200 €).

a

> 47 movimenti: 40 spese **per 3200 €**, 5 entrate **per 4500 €** e 2 trasferimenti **per 500 €**, di cui 2 in calendario (406 €); la voce più grande è Stipendio (4200 €).

e sul caso che l'ha motivata:

> 120 movimenti: 120 spese per 264 €; la voce più grande è caffè (4 €).

I totali sono quelli delle righe che la lista **mostra**, quindi seguono la toolbar: il periodo resta la voce delle tessere sopra, che non passano mai da `filteredExpenses`. La clausola «di cui … in calendario» resta dov'era e continua a decomporre il conteggio.

**2. Il periodo dentro il tile, sul telefono.** `MobileFiltersDrawer` sapeva già renderlo (`showPeriod`), Tracciamento lo spegneva. Ora sotto `desktop:` la barra del tile è `[periodo] [Filtri ①] [⇅]` e guida lo **stesso** stato del picker sotto il verdetto: un asse, due maniglie, mai due assi. Il prop `showPeriod`, che a quel punto nessuno metteva più a `false`, è stato tolto.

## Limiti, dichiarati

- I totali stampano in **euro interi** come ogni lettura della pagina (`euro` è la forma compatta): una ricerca su righe da pochi centesimi arrotonda.
- Seguono la **toolbar**, non il periodo — è il punto, ma va letto sapendolo: le cifre del periodo sono quelle delle tessere sopra.

## Verifica

- `npx tsc --noEmit` pulito, `npm run lint` pulito sui file toccati.
- `TZ=Europe/Rome npx vitest run` → **151 file / 3445 test** verdi. Le frasi nuove sono bloccate parola per parola (somma per tipo, il caso «una nota sola», il meno su un'entrata stornata, i singolari, la convivenza con «di cui … in calendario»).
- Collaudo su emulatore + Playwright a 390px con parole-esca inesistenti altrove nei dati: `fenicottero` nel mese → «3 spese per 24 €»; `ornitorinco` → «1 spesa per 30 € e 1 entrata per 99 €»; dal picker **dentro** il tile, «Quest'anno» → «4 spese per 124 €», con il picker in alto che lo segue. Entrambe le funzioni rotte di proposito una volta per vedere le asserzioni rosse. Fixture e spec usa-e-getta rimosse a fine collaudo (non sono in questo diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UavwgWVz6AdJ16cvDtEUfK